### PR TITLE
feat: add two-screen onboarding flow with notification permission

### DIFF
--- a/__mocks__/expo-notifications.js
+++ b/__mocks__/expo-notifications.js
@@ -1,0 +1,4 @@
+module.exports = {
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'undetermined' })),
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo": "~54.0.33",
     "expo-build-properties": "~1.0.10",
     "expo-dev-client": "~6.0.21",
+    "expo-notifications": "^55.0.22",
     "expo-status-bar": "~3.0.9",
     "i18next": "^26.0.8",
     "react": "19.1.0",
@@ -53,7 +54,8 @@
   "jest": {
     "preset": "jest-expo",
     "moduleNameMapper": {
-      "@react-native-async-storage/async-storage": "<rootDir>/__mocks__/@react-native-async-storage/async-storage.js"
+      "@react-native-async-storage/async-storage": "<rootDir>/__mocks__/@react-native-async-storage/async-storage.js",
+      "expo-notifications": "<rootDir>/__mocks__/expo-notifications.js"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       expo-dev-client:
         specifier: ~6.0.21
         version: 6.0.21(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-notifications:
+        specifier: ^55.0.22
+        version: 55.0.22(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -690,6 +693,10 @@ packages:
 
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
+
+  '@expo/env@2.1.1':
+    resolution: {integrity: sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==}
+    engines: {node: '>=20.12.0'}
 
   '@expo/fingerprint@0.15.5':
     resolution: {integrity: sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==}
@@ -1880,6 +1887,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2511,6 +2521,11 @@ packages:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  expo-application@55.0.14:
+    resolution: {integrity: sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@12.0.13:
     resolution: {integrity: sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==}
     peerDependencies:
@@ -2525,6 +2540,12 @@ packages:
 
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
+  expo-constants@55.0.15:
+    resolution: {integrity: sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -2583,6 +2604,13 @@ packages:
   expo-modules-core@3.0.30:
     resolution: {integrity: sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-notifications@55.0.22:
+    resolution: {integrity: sha512-Rwvsp/lAEXfDYBxkQZpaLF9ZB25cJ/yfHhD/ESclbPesN0nbQBZ/5rGb1xS/saANtkStbEGfDlA80uHh2zEpsA==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -5765,6 +5793,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/env@2.1.1':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/fingerprint@0.15.5':
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -7405,6 +7441,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -8157,6 +8195,10 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
+  expo-application@55.0.14(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+
   expo-asset@12.0.13(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
@@ -8178,6 +8220,14 @@ snapshots:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
+      expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@55.0.15(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      '@expo/env': 2.1.1
       expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
@@ -8252,6 +8302,20 @@ snapshots:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo-notifications@55.0.22(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.13(typescript@5.9.3)
+      abort-controller: 3.0.0
+      badgin: 1.2.3
+      expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 55.0.14(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-constants: 55.0.15(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-server@1.0.6: {}
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -10,6 +10,17 @@ const en = {
   settings: {
     languageTitle: 'Language',
   },
+  onboarding: {
+    heading: 'Yomoyo',
+    concept: "When someone you follow finishes a book, you'll know.",
+    signInWithGoogle: 'Sign in with Google',
+    signInWithApple: 'Sign in with Apple',
+    signInError: 'Sign-in failed. Please try again.',
+    notificationHeading: 'One quiet update',
+    notificationBody: 'Only when someone you follow finishes a book.',
+    allowButton: 'Allow notifications',
+    skipLink: 'Maybe later',
+  },
 } as const;
 
 export default en;

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -10,6 +10,17 @@ const ja = {
   settings: {
     languageTitle: '言語',
   },
+  onboarding: {
+    heading: 'Yomoyo',
+    concept: 'フォローしている人が本を読み終えたとき、そっと知らせます。',
+    signInWithGoogle: 'Googleでサインイン',
+    signInWithApple: 'Appleでサインイン',
+    signInError: 'サインインに失敗しました。もう一度お試しください。',
+    notificationHeading: 'ひとつの静かなお知らせ',
+    notificationBody: 'フォローしている人が本を読み終えたときだけ。',
+    allowButton: '通知を許可する',
+    skipLink: '後で',
+  },
 } as const;
 
 export default ja;

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -1,0 +1,30 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { checkFirstLaunch, markOnboardingDone, ONBOARDING_KEY } from '@/lib/onboarding';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('checkFirstLaunch', () => {
+  it('returns true when no onboarding record exists', async () => {
+    jest.mocked(AsyncStorage.getItem).mockResolvedValueOnce(null);
+    expect(await checkFirstLaunch()).toBe(true);
+  });
+
+  it('returns false when onboarding is already done', async () => {
+    jest.mocked(AsyncStorage.getItem).mockResolvedValueOnce('true');
+    expect(await checkFirstLaunch()).toBe(false);
+  });
+});
+
+describe('markOnboardingDone', () => {
+  it('saves the onboarding key to AsyncStorage', async () => {
+    await markOnboardingDone();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(ONBOARDING_KEY, 'true');
+  });
+});

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,12 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const ONBOARDING_KEY = 'yomoyo_onboarding_done';
+
+export async function checkFirstLaunch(): Promise<boolean> {
+  const done = await AsyncStorage.getItem(ONBOARDING_KEY);
+  return done === null;
+}
+
+export async function markOnboardingDone(): Promise<void> {
+  await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
+}

--- a/src/navigation/OnboardingNavigator.tsx
+++ b/src/navigation/OnboardingNavigator.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import OnboardingWelcomeScreen from '@/screens/OnboardingWelcomeScreen';
+import OnboardingNotificationScreen from '@/screens/OnboardingNotificationScreen';
+import type { OnboardingStackParamList } from './types';
+
+const Stack = createNativeStackNavigator<OnboardingStackParamList>();
+
+type Props = {
+  onComplete: () => void;
+};
+
+export default function OnboardingNavigator({ onComplete }: Props) {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="OnboardingWelcome" component={OnboardingWelcomeScreen} />
+      <Stack.Screen name="OnboardingNotification">
+        {() => <OnboardingNotificationScreen onComplete={onComplete} />}
+      </Stack.Screen>
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/RootNavigator.test.tsx
+++ b/src/navigation/RootNavigator.test.tsx
@@ -20,6 +20,19 @@ jest.mock('@/navigation/AppNavigator', () => {
   };
 });
 
+jest.mock('@/navigation/OnboardingNavigator', () => {
+  const { Text } = require('react-native');
+  return function OnboardingNavigator() {
+    return <Text>OnboardingNavigator</Text>;
+  };
+});
+
+jest.mock('@/lib/onboarding', () => ({
+  checkFirstLaunch: jest.fn(),
+}));
+
+import { checkFirstLaunch } from '@/lib/onboarding';
+
 function renderWithNav() {
   return render(
     <NavigationContainer>
@@ -29,35 +42,50 @@ function renderWithNav() {
 }
 
 describe('RootNavigator', () => {
+  beforeEach(() => {
+    jest.mocked(checkFirstLaunch).mockResolvedValue(false);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('shows LoginScreen when user is null', () => {
+  it('shows LoginScreen when onboarding is done and user is null', async () => {
     jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({ user: null, loading: false });
-
     renderWithNav();
-
-    expect(screen.getByText('LoginScreen')).toBeTruthy();
+    expect(await screen.findByText('LoginScreen')).toBeTruthy();
   });
 
-  it('shows AppNavigator when user is authenticated', () => {
+  it('shows AppNavigator when onboarding is done and user is authenticated', async () => {
     jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({
       user: { uid: 'abc123' } as any,
       loading: false,
     });
-
     renderWithNav();
-
-    expect(screen.getByText('AppNavigator')).toBeTruthy();
+    expect(await screen.findByText('AppNavigator')).toBeTruthy();
   });
 
-  it('shows nothing while the auth state is loading', () => {
+  it('shows nothing while auth state is loading', () => {
     jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({ user: null, loading: true });
-
     renderWithNav();
-
     expect(screen.queryByText('LoginScreen')).toBeNull();
     expect(screen.queryByText('AppNavigator')).toBeNull();
+  });
+
+  it('shows OnboardingNavigator on first launch', async () => {
+    jest.mocked(checkFirstLaunch).mockResolvedValue(true);
+    jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({ user: null, loading: false });
+    renderWithNav();
+    expect(await screen.findByText('OnboardingNavigator')).toBeTruthy();
+  });
+
+  it('shows OnboardingNavigator on first launch even when user is already signed in', async () => {
+    jest.mocked(checkFirstLaunch).mockResolvedValue(true);
+    jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      user: { uid: 'abc123' } as any,
+      loading: false,
+    });
+    renderWithNav();
+    expect(await screen.findByText('OnboardingNavigator')).toBeTruthy();
   });
 });

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import AppNavigator from './AppNavigator';
+import OnboardingNavigator from './OnboardingNavigator';
 import LoginScreen from '@/screens/LoginScreen';
 import { useAuth } from '@/hooks/useAuth';
+import { checkFirstLaunch } from '@/lib/onboarding';
 
 type AuthStackParamList = {
   App: undefined;
@@ -13,9 +15,22 @@ const Stack = createNativeStackNavigator<AuthStackParamList>();
 
 export default function RootNavigator() {
   const { user, loading } = useAuth();
+  const [onboardingDone, setOnboardingDone] = useState<boolean | null>(null);
 
-  if (loading) {
+  useEffect(() => {
+    checkFirstLaunch()
+      .then((isFirst) => setOnboardingDone(!isFirst))
+      .catch(() => setOnboardingDone(true));
+  }, []);
+
+  if (loading || onboardingDone === null) {
     return null;
+  }
+
+  if (!onboardingDone) {
+    return (
+      <OnboardingNavigator onComplete={() => setOnboardingDone(true)} />
+    );
   }
 
   return (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -8,3 +8,8 @@ export type MainTabParamList = {
   Friends: undefined;
   Settings: undefined;
 };
+
+export type OnboardingStackParamList = {
+  OnboardingWelcome: undefined;
+  OnboardingNotification: undefined;
+};

--- a/src/screens/OnboardingNotificationScreen.test.tsx
+++ b/src/screens/OnboardingNotificationScreen.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import OnboardingNotificationScreen from './OnboardingNotificationScreen';
+import * as Notifications from 'expo-notifications';
+import { markOnboardingDone } from '@/lib/onboarding';
+
+jest.mock('expo-notifications');
+
+jest.mock('@/lib/onboarding', () => ({
+  markOnboardingDone: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockOnComplete = jest.fn();
+
+describe('OnboardingNotificationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnComplete.mockClear();
+  });
+
+  it('renders the notification heading key', () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    expect(screen.getByText('onboarding.notificationHeading')).toBeTruthy();
+  });
+
+  it('renders the notification body key', () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    expect(screen.getByText('onboarding.notificationBody')).toBeTruthy();
+  });
+
+  it('renders an allow button', () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    expect(screen.getByText('onboarding.allowButton')).toBeTruthy();
+  });
+
+  it('renders a skip option', () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    expect(screen.getByText('onboarding.skipLink')).toBeTruthy();
+  });
+
+  it('requests notification permission when allow is pressed', async () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    fireEvent.press(screen.getByText('onboarding.allowButton'));
+    await waitFor(() =>
+      expect(Notifications.requestPermissionsAsync).toHaveBeenCalled()
+    );
+  });
+
+  it('marks onboarding done and calls onComplete after allow', async () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    fireEvent.press(screen.getByText('onboarding.allowButton'));
+    await waitFor(() => expect(markOnboardingDone).toHaveBeenCalled());
+    await waitFor(() => expect(mockOnComplete).toHaveBeenCalled());
+  });
+
+  it('marks onboarding done and calls onComplete after skip', async () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    fireEvent.press(screen.getByText('onboarding.skipLink'));
+    await waitFor(() => expect(markOnboardingDone).toHaveBeenCalled());
+    await waitFor(() => expect(mockOnComplete).toHaveBeenCalled());
+  });
+
+  it('does not request permission when skip is pressed', async () => {
+    render(<OnboardingNotificationScreen onComplete={mockOnComplete} />);
+    fireEvent.press(screen.getByText('onboarding.skipLink'));
+    await waitFor(() => expect(mockOnComplete).toHaveBeenCalled());
+    expect(Notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/OnboardingNotificationScreen.tsx
+++ b/src/screens/OnboardingNotificationScreen.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import * as Notifications from 'expo-notifications';
+import { markOnboardingDone } from '@/lib/onboarding';
+
+type Props = {
+  onComplete: () => void;
+};
+
+export default function OnboardingNotificationScreen({ onComplete }: Props) {
+  const { t } = useTranslation();
+
+  const handleAllow = async () => {
+    await Notifications.requestPermissionsAsync();
+    await markOnboardingDone();
+    onComplete();
+  };
+
+  const handleSkip = async () => {
+    await markOnboardingDone();
+    onComplete();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>{t('onboarding.notificationHeading')}</Text>
+      <Text style={styles.body}>{t('onboarding.notificationBody')}</Text>
+      <TouchableOpacity style={styles.button} onPress={handleAllow} accessibilityRole="button">
+        <Text style={styles.buttonText}>{t('onboarding.allowButton')}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={handleSkip} accessibilityRole="button">
+        <Text style={styles.skip}>{t('onboarding.skipLink')}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    backgroundColor: '#fff',
+  },
+  heading: { fontSize: 24, fontWeight: '600', marginBottom: 16 },
+  body: { fontSize: 16, color: '#555', textAlign: 'center', marginBottom: 48, lineHeight: 24 },
+  button: {
+    width: '100%',
+    paddingVertical: 14,
+    borderRadius: 8,
+    backgroundColor: '#4285F4',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  skip: { fontSize: 15, color: '#888' },
+});

--- a/src/screens/OnboardingWelcomeScreen.test.tsx
+++ b/src/screens/OnboardingWelcomeScreen.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import OnboardingWelcomeScreen from './OnboardingWelcomeScreen';
+import { signInWithGoogle } from '@/lib/auth/google';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/lib/auth/google', () => ({
+  signInWithGoogle: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/auth/apple', () => ({
+  signInWithApple: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('OnboardingWelcomeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockClear();
+  });
+
+  it('renders the heading key', () => {
+    render(<OnboardingWelcomeScreen />);
+    expect(screen.getByText('onboarding.heading')).toBeTruthy();
+  });
+
+  it('renders the concept text key', () => {
+    render(<OnboardingWelcomeScreen />);
+    expect(screen.getByText('onboarding.concept')).toBeTruthy();
+  });
+
+  it('renders a Google sign-in button', () => {
+    render(<OnboardingWelcomeScreen />);
+    expect(screen.getByText('onboarding.signInWithGoogle')).toBeTruthy();
+  });
+
+  it('calls signInWithGoogle when the Google button is pressed', async () => {
+    render(<OnboardingWelcomeScreen />);
+    fireEvent.press(screen.getByText('onboarding.signInWithGoogle'));
+    await waitFor(() => expect(signInWithGoogle).toHaveBeenCalled());
+  });
+
+  it('navigates to OnboardingNotification after Google sign-in succeeds', async () => {
+    render(<OnboardingWelcomeScreen />);
+    fireEvent.press(screen.getByText('onboarding.signInWithGoogle'));
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('OnboardingNotification')
+    );
+  });
+
+  it('does not navigate when sign-in is cancelled', async () => {
+    jest.mocked(signInWithGoogle).mockRejectedValueOnce(new Error('cancelled'));
+    render(<OnboardingWelcomeScreen />);
+    fireEvent.press(screen.getByText('onboarding.signInWithGoogle'));
+    await waitFor(() => expect(signInWithGoogle).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/OnboardingWelcomeScreen.tsx
+++ b/src/screens/OnboardingWelcomeScreen.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, Platform, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { signInWithGoogle } from '@/lib/auth/google';
+import { signInWithApple } from '@/lib/auth/apple';
+import type { OnboardingStackParamList } from '@/navigation/types';
+
+type Nav = NativeStackNavigationProp<OnboardingStackParamList, 'OnboardingWelcome'>;
+
+export default function OnboardingWelcomeScreen() {
+  const navigation = useNavigation<Nav>();
+  const { t } = useTranslation();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGoogleSignIn = async () => {
+    setError(null);
+    try {
+      await signInWithGoogle();
+      navigation.navigate('OnboardingNotification');
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('cancelled')) return;
+      setError(t('onboarding.signInError'));
+    }
+  };
+
+  const handleAppleSignIn = async () => {
+    setError(null);
+    try {
+      await signInWithApple();
+      navigation.navigate('OnboardingNotification');
+    } catch {
+      setError(t('onboarding.signInError'));
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>{t('onboarding.heading')}</Text>
+      <Text style={styles.concept}>{t('onboarding.concept')}</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TouchableOpacity style={styles.button} onPress={handleGoogleSignIn} accessibilityRole="button">
+        <Text style={styles.buttonText}>{t('onboarding.signInWithGoogle')}</Text>
+      </TouchableOpacity>
+      {Platform.OS === 'ios' && (
+        <TouchableOpacity style={[styles.button, styles.appleButton]} onPress={handleAppleSignIn} accessibilityRole="button">
+          <Text style={[styles.buttonText]}>{t('onboarding.signInWithApple')}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    backgroundColor: '#fff',
+  },
+  heading: { fontSize: 36, fontWeight: '700', marginBottom: 16 },
+  concept: { fontSize: 16, color: '#555', textAlign: 'center', marginBottom: 48, lineHeight: 24 },
+  error: { color: '#d32f2f', fontSize: 14, marginBottom: 16, textAlign: 'center' },
+  button: {
+    width: '100%',
+    paddingVertical: 14,
+    borderRadius: 8,
+    backgroundColor: '#4285F4',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  appleButton: { backgroundColor: '#000' },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+});


### PR DESCRIPTION
- Add checkFirstLaunch/markOnboardingDone via AsyncStorage
- Add OnboardingWelcomeScreen (Google/Apple sign-in) and OnboardingNotificationScreen (expo-notifications permission)
- Add OnboardingNavigator routing between the two screens
- Gate RootNavigator on onboardingDone state, separate from auth state
- Add expo-notifications package with Jest mock; add onboarding i18n strings