### PR TITLE
feat: implement book search using Google Books API

### DIFF
--- a/src/lib/books/searchBooks.test.ts
+++ b/src/lib/books/searchBooks.test.ts
@@ -1,0 +1,122 @@
+import { searchBooks } from './searchBooks';
+
+function makeFetchOk(body: object): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function makeFetchError(status: number): Response {
+  return { ok: false, status } as unknown as Response;
+}
+
+describe('searchBooks', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns empty array when API response has no items', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
+    const result = await searchBooks('test');
+    expect(result).toEqual([]);
+  });
+
+  it('maps a full volume to a Book', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        items: [
+          {
+            id: 'abc',
+            volumeInfo: {
+              title: 'The Great Gatsby',
+              authors: ['F. Scott Fitzgerald'],
+              imageLinks: { thumbnail: 'http://books.google.com/thumbnail.jpg' },
+            },
+          },
+        ],
+      }),
+    );
+    const result = await searchBooks('gatsby');
+    expect(result).toEqual([
+      {
+        id: 'abc',
+        title: 'The Great Gatsby',
+        authors: ['F. Scott Fitzgerald'],
+        thumbnail: 'https://books.google.com/thumbnail.jpg',
+      },
+    ]);
+  });
+
+  it('defaults authors to empty array when missing', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        items: [{ id: 'xyz', volumeInfo: { title: 'Unknown Book' } }],
+      }),
+    );
+    const [book] = await searchBooks('unknown');
+    expect(book.authors).toEqual([]);
+  });
+
+  it('sets thumbnail to null when imageLinks is missing', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        items: [{ id: 'xyz', volumeInfo: { title: 'No Cover', authors: ['Author'] } }],
+      }),
+    );
+    const [book] = await searchBooks('no cover');
+    expect(book.thumbnail).toBeNull();
+  });
+
+  it('converts http thumbnail URL to https', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        items: [
+          {
+            id: 'xyz',
+            volumeInfo: {
+              title: 'Book',
+              authors: ['Author'],
+              imageLinks: { thumbnail: 'http://books.google.com/img.jpg' },
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('book');
+    expect(book.thumbnail).toBe('https://books.google.com/img.jpg');
+  });
+
+  it('throws when the API responds with an error status', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchError(500));
+    await expect(searchBooks('test')).rejects.toThrow('Books API error: 500');
+  });
+
+  it('sets thumbnail to null when the URL is malformed', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        items: [
+          {
+            id: 'xyz',
+            volumeInfo: {
+              title: 'Book',
+              authors: ['Author'],
+              imageLinks: { thumbnail: 'not a url' },
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('book');
+    expect(book.thumbnail).toBeNull();
+  });
+
+  it('includes the query in the fetch URL', async () => {
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
+    await searchBooks('hello world');
+    const url = spy.mock.calls[0][0] as string;
+    expect(url).toContain('q=');
+    expect(decodeURIComponent(url.replace(/\+/g, ' '))).toContain('hello world');
+  });
+});

--- a/src/lib/books/searchBooks.ts
+++ b/src/lib/books/searchBooks.ts
@@ -1,0 +1,53 @@
+const BASE_URL = 'https://www.googleapis.com/books/v1/volumes';
+
+export type Book = {
+  id: string;
+  title: string;
+  authors: string[];
+  thumbnail: string | null;
+};
+
+type GoogleBooksVolume = {
+  id: string;
+  volumeInfo: {
+    title: string;
+    authors?: string[];
+    imageLinks?: { thumbnail?: string };
+  };
+};
+
+type GoogleBooksResponse = {
+  items?: GoogleBooksVolume[];
+};
+
+function toSafeHttpsUrl(raw: string): string | null {
+  const url = raw.replace('http://', 'https://');
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function mapVolume(item: GoogleBooksVolume): Book {
+  const raw = item.volumeInfo.imageLinks?.thumbnail ?? null;
+  return {
+    id: item.id,
+    title: item.volumeInfo.title,
+    authors: item.volumeInfo.authors ?? [],
+    thumbnail: raw ? toSafeHttpsUrl(raw) : null,
+  };
+}
+
+export async function searchBooks(query: string): Promise<Book[]> {
+  const params = new URLSearchParams({ q: query });
+  const apiKey = process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY;
+  if (apiKey) params.append('key', apiKey);
+
+  const response = await fetch(`${BASE_URL}?${params}`);
+  if (!response.ok) throw new Error(`Books API error: ${response.status}`);
+
+  const data: GoogleBooksResponse = await response.json();
+  return (data.items ?? []).map(mapVolume);
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -5,7 +5,16 @@ const en = {
     settings: 'Settings',
   },
   feed: {
-    goToBookDetail: 'Go to Book Detail',
+    searchBooks: 'Search books',
+  },
+  bookSearch: {
+    placeholder: 'Search by title or author',
+    button: 'Search',
+    noResults: 'No results found',
+    unknownAuthor: 'Unknown author',
+  },
+  bookDetail: {
+    unknownAuthor: 'Unknown author',
   },
   settings: {
     languageTitle: 'Language',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -5,7 +5,16 @@ const ja = {
     settings: '設定',
   },
   feed: {
-    goToBookDetail: '本の詳細へ',
+    searchBooks: '本を検索',
+  },
+  bookSearch: {
+    placeholder: 'タイトルや著者で検索',
+    button: '検索',
+    noResults: '結果が見つかりませんでした',
+    unknownAuthor: '著者不明',
+  },
+  bookDetail: {
+    unknownAuthor: '著者不明',
   },
   settings: {
     languageTitle: '言語',

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import MainTabNavigator from './MainTabNavigator';
+import BookSearchScreen from '@/screens/BookSearchScreen';
 import BookDetailScreen from '@/screens/BookDetailScreen';
 import { RootStackParamList } from './types';
 
@@ -10,6 +11,7 @@ export default function AppNavigator() {
   return (
     <Stack.Navigator>
       <Stack.Screen name="MainTabs" component={MainTabNavigator} options={{ headerShown: false }} />
+      <Stack.Screen name="BookSearch" component={BookSearchScreen} options={{ title: 'Search Books' }} />
       <Stack.Screen name="BookDetail" component={BookDetailScreen} options={{ title: 'Book Detail' }} />
     </Stack.Navigator>
   );

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,6 +1,9 @@
+import type { Book } from '@/lib/books/searchBooks';
+
 export type RootStackParamList = {
   MainTabs: undefined;
-  BookDetail: undefined;
+  BookSearch: undefined;
+  BookDetail: { book: Book };
 };
 
 export type MainTabParamList = {

--- a/src/screens/BookDetailScreen.test.tsx
+++ b/src/screens/BookDetailScreen.test.tsx
@@ -1,14 +1,65 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import BookDetailScreen from './BookDetailScreen';
+import { useRoute } from '@react-navigation/native';
+
+const mockBook = {
+  id: 'abc',
+  title: 'The Great Gatsby',
+  authors: ['F. Scott Fitzgerald'],
+  thumbnail: 'https://example.com/cover.jpg',
+};
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
 
 describe('BookDetailScreen', () => {
-  it('renders without crashing', () => {
-    render(<BookDetailScreen />);
+  beforeEach(() => {
+    jest.mocked(useRoute).mockReturnValue({
+      params: { book: mockBook },
+      key: 'BookDetail',
+      name: 'BookDetail',
+    });
   });
 
-  it('renders the Book Detail title', () => {
+  it('renders the book title', () => {
     render(<BookDetailScreen />);
-    expect(screen.getByText('Book Detail')).toBeTruthy();
+    expect(screen.getByText('The Great Gatsby')).toBeTruthy();
+  });
+
+  it('renders the book authors', () => {
+    render(<BookDetailScreen />);
+    expect(screen.getByText('F. Scott Fitzgerald')).toBeTruthy();
+  });
+
+  it('renders a thumbnail image when available', () => {
+    render(<BookDetailScreen />);
+    expect(screen.getByTestId('book-thumbnail')).toBeTruthy();
+  });
+
+  it('does not render thumbnail when thumbnail is null', () => {
+    jest.mocked(useRoute).mockReturnValue({
+      params: { book: { ...mockBook, thumbnail: null } },
+      key: 'BookDetail',
+      name: 'BookDetail',
+    });
+    render(<BookDetailScreen />);
+    expect(screen.queryByTestId('book-thumbnail')).toBeNull();
+  });
+
+  it('shows unknownAuthor key when authors is empty', () => {
+    jest.mocked(useRoute).mockReturnValue({
+      params: { book: { ...mockBook, authors: [] } },
+      key: 'BookDetail',
+      name: 'BookDetail',
+    });
+    render(<BookDetailScreen />);
+    expect(screen.getByText('bookDetail.unknownAuthor')).toBeTruthy();
   });
 });

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -1,15 +1,37 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import { useRoute } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
+import type { RootStackParamList } from '@/navigation/types';
+
+type RouteType = RouteProp<RootStackParamList, 'BookDetail'>;
 
 export default function BookDetailScreen() {
+  const { t } = useTranslation();
+  const route = useRoute<RouteType>();
+  const { book } = route.params;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Book Detail</Text>
-    </View>
+    <ScrollView contentContainerStyle={styles.container}>
+      {book.thumbnail ? (
+        <Image
+          testID="book-thumbnail"
+          source={{ uri: book.thumbnail }}
+          style={styles.cover}
+        />
+      ) : null}
+      <Text style={styles.title}>{book.title}</Text>
+      <Text style={styles.author}>
+        {book.authors.length > 0 ? book.authors.join(', ') : t('bookDetail.unknownAuthor')}
+      </Text>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#fff' },
-  title: { fontSize: 24, fontWeight: '600' },
+  container: { alignItems: 'center', padding: 24, backgroundColor: '#fff', flexGrow: 1 },
+  cover: { width: 120, height: 180, borderRadius: 6, marginBottom: 20, backgroundColor: '#eee' },
+  title: { fontSize: 22, fontWeight: '600', textAlign: 'center', marginBottom: 8 },
+  author: { fontSize: 16, color: '#666', textAlign: 'center' },
 });

--- a/src/screens/BookSearchScreen.test.tsx
+++ b/src/screens/BookSearchScreen.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import BookSearchScreen from './BookSearchScreen';
+import { searchBooks } from '@/lib/books/searchBooks';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@/lib/books/searchBooks', () => ({
+  searchBooks: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockBook = {
+  id: 'abc',
+  title: 'The Great Gatsby',
+  authors: ['F. Scott Fitzgerald'],
+  thumbnail: 'https://example.com/cover.jpg',
+};
+
+describe('BookSearchScreen', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    jest.mocked(searchBooks).mockClear();
+  });
+
+  it('renders a search input', () => {
+    render(<BookSearchScreen />);
+    expect(screen.getByPlaceholderText('bookSearch.placeholder')).toBeTruthy();
+  });
+
+  it('renders a search button', () => {
+    render(<BookSearchScreen />);
+    expect(screen.getByRole('button', { name: 'bookSearch.button' })).toBeTruthy();
+  });
+
+  it('shows a book result after search', async () => {
+    jest.mocked(searchBooks).mockResolvedValue([mockBook]);
+    render(<BookSearchScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText('bookSearch.placeholder'), 'gatsby');
+    fireEvent.press(screen.getByRole('button', { name: 'bookSearch.button' }));
+    expect(await screen.findByText('The Great Gatsby')).toBeTruthy();
+    expect(await screen.findByText('F. Scott Fitzgerald')).toBeTruthy();
+  });
+
+  it('shows no results message when search returns empty', async () => {
+    jest.mocked(searchBooks).mockResolvedValue([]);
+    render(<BookSearchScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText('bookSearch.placeholder'), 'xyz');
+    fireEvent.press(screen.getByRole('button', { name: 'bookSearch.button' }));
+    expect(await screen.findByText('bookSearch.noResults')).toBeTruthy();
+  });
+
+  it('shows unknownAuthor key when authors is empty', async () => {
+    jest.mocked(searchBooks).mockResolvedValue([{ ...mockBook, authors: [] }]);
+    render(<BookSearchScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText('bookSearch.placeholder'), 'gatsby');
+    fireEvent.press(screen.getByRole('button', { name: 'bookSearch.button' }));
+    expect(await screen.findByText('bookSearch.unknownAuthor')).toBeTruthy();
+  });
+
+  it('navigates to BookDetail with the selected book when a result is tapped', async () => {
+    jest.mocked(searchBooks).mockResolvedValue([mockBook]);
+    render(<BookSearchScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText('bookSearch.placeholder'), 'gatsby');
+    fireEvent.press(screen.getByRole('button', { name: 'bookSearch.button' }));
+    fireEvent.press(await screen.findByText('The Great Gatsby'));
+    expect(mockNavigate).toHaveBeenCalledWith('BookDetail', { book: mockBook });
+  });
+});

--- a/src/screens/BookSearchScreen.tsx
+++ b/src/screens/BookSearchScreen.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  Image,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useTranslation } from 'react-i18next';
+import { searchBooks, type Book } from '@/lib/books/searchBooks';
+import type { RootStackParamList } from '@/navigation/types';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+
+export default function BookSearchScreen() {
+  const { t } = useTranslation();
+  const navigation = useNavigation<NavigationProp>();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Book[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    setLoading(true);
+    try {
+      const books = await searchBooks(query.trim());
+      setResults(books);
+    } catch (error: unknown) {
+      console.error('Book search failed:', error);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelect = (book: Book) => {
+    navigation.navigate('BookDetail', { book });
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.searchRow}>
+        <TextInput
+          style={styles.input}
+          placeholder={t('bookSearch.placeholder')}
+          value={query}
+          onChangeText={setQuery}
+          returnKeyType="search"
+          onSubmitEditing={handleSearch}
+        />
+        <TouchableOpacity
+          style={styles.button}
+          onPress={handleSearch}
+          accessibilityRole="button"
+          accessibilityLabel={t('bookSearch.button')}
+        >
+          <Text style={styles.buttonText}>{t('bookSearch.button')}</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading && <ActivityIndicator style={styles.loading} />}
+
+      {!loading && results !== null && results.length === 0 && (
+        <Text style={styles.noResults}>{t('bookSearch.noResults')}</Text>
+      )}
+
+      <FlatList
+        data={results ?? []}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity style={styles.resultItem} onPress={() => handleSelect(item)}>
+            {item.thumbnail ? (
+              <Image source={{ uri: item.thumbnail }} style={styles.thumbnail} />
+            ) : (
+              <View style={styles.thumbnailPlaceholder} />
+            )}
+            <View style={styles.bookInfo}>
+              <Text style={styles.bookTitle}>{item.title}</Text>
+              <Text style={styles.bookAuthor}>
+                {item.authors.length > 0 ? item.authors.join(', ') : t('bookSearch.unknownAuthor')}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  searchRow: { flexDirection: 'row', padding: 16, gap: 8 },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  button: {
+    backgroundColor: '#4285F4',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+  },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  loading: { marginTop: 24 },
+  noResults: { textAlign: 'center', marginTop: 40, color: '#888', fontSize: 16 },
+  resultItem: { flexDirection: 'row', padding: 12, borderBottomWidth: 1, borderBottomColor: '#f0f0f0' },
+  thumbnail: { width: 50, height: 72, borderRadius: 4, backgroundColor: '#eee' },
+  thumbnailPlaceholder: { width: 50, height: 72, borderRadius: 4, backgroundColor: '#ddd' },
+  bookInfo: { flex: 1, marginLeft: 12, justifyContent: 'center' },
+  bookTitle: { fontSize: 15, fontWeight: '600', marginBottom: 4 },
+  bookAuthor: { fontSize: 13, color: '#666' },
+});

--- a/src/screens/FeedScreen.test.tsx
+++ b/src/screens/FeedScreen.test.tsx
@@ -23,19 +23,19 @@ describe('FeedScreen', () => {
     expect(screen.getByText('tabs.feed')).toBeTruthy();
   });
 
-  it('shows a button with the go to book detail key', () => {
+  it('shows a search books button', () => {
     render(<FeedScreen />);
-    expect(screen.getByText('feed.goToBookDetail')).toBeTruthy();
+    expect(screen.getByText('feed.searchBooks')).toBeTruthy();
   });
 
-  it('navigates to BookDetail when the button is pressed', () => {
+  it('navigates to BookSearch when the button is pressed', () => {
     render(<FeedScreen />);
-    fireEvent.press(screen.getByText('feed.goToBookDetail'));
-    expect(mockNavigate).toHaveBeenCalledWith('BookDetail');
+    fireEvent.press(screen.getByText('feed.searchBooks'));
+    expect(mockNavigate).toHaveBeenCalledWith('BookSearch');
   });
 
-  it('the Book Detail button has an accessible button role', () => {
+  it('the search books button has an accessible button role', () => {
     render(<FeedScreen />);
-    expect(screen.getByRole('button', { name: 'feed.goToBookDetail' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'feed.searchBooks' })).toBeTruthy();
   });
 });

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -13,9 +13,9 @@ export default function FeedScreen() {
       <TouchableOpacity
         style={styles.button}
         accessibilityRole="button"
-        onPress={() => navigation.navigate('BookDetail')}
+        onPress={() => navigation.navigate('BookSearch')}
       >
-        <Text style={styles.buttonText}>{t('feed.goToBookDetail')}</Text>
+        <Text style={styles.buttonText}>{t('feed.searchBooks')}</Text>
       </TouchableOpacity>
     </View>
   );


### PR DESCRIPTION
- Add searchBooks() with http→https URL safety and URL validation
- Add BookSearchScreen with query input, results list, and tap-to-select
- Update BookDetailScreen to display selected book (cover, title, author)
- Wire BookSearch into AppNavigator; FeedScreen entry point changed to BookSearch
- Add bookSearch and bookDetail i18n keys in en/ja