### PR TITLE
feat: add My Shelf screen with currently reading and finished sections

### DIFF
--- a/src/components/ui/GlassTabBar.tsx
+++ b/src/components/ui/GlassTabBar.tsx
@@ -12,6 +12,7 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 const TAB_ICONS: Record<string, { active: IoniconName; inactive: IoniconName }> = {
   Feed: { active: 'book', inactive: 'book-outline' },
   Friends: { active: 'people', inactive: 'people-outline' },
+  Shelf: { active: 'library', inactive: 'library-outline' },
   Settings: { active: 'settings', inactive: 'settings-outline' },
 };
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -2,6 +2,7 @@ const en = {
   tabs: {
     feed: 'Feed',
     friends: 'Friends',
+    shelf: 'My Shelf',
     settings: 'Settings',
   },
   feed: {
@@ -26,6 +27,12 @@ const en = {
     unknownAuthor: 'Unknown author',
     startReading: 'Start Reading',
     reading: 'Reading',
+  },
+  shelf: {
+    currentlyReading: 'Currently Reading',
+    finished: 'Finished',
+    emptyCurrentlyReading: 'No books currently reading',
+    emptyFinished: 'No finished books yet',
   },
   settings: {
     languageTitle: 'Language',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -2,6 +2,7 @@ const ja = {
   tabs: {
     feed: 'フィード',
     friends: 'フレンド',
+    shelf: '本棚',
     settings: '設定',
   },
   feed: {
@@ -26,6 +27,12 @@ const ja = {
     unknownAuthor: '著者不明',
     startReading: '読み始める',
     reading: '読書中',
+  },
+  shelf: {
+    currentlyReading: '読書中',
+    finished: '読了',
+    emptyCurrentlyReading: '読書中の本はまだありません',
+    emptyFinished: '読了した本はまだありません',
   },
   settings: {
     languageTitle: '言語',

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -3,6 +3,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useTranslation } from 'react-i18next';
 import FeedScreen from '@/screens/FeedScreen';
 import FriendsScreen from '@/screens/FriendsScreen';
+import ShelfScreen from '@/screens/ShelfScreen';
 import SettingsScreen from '@/screens/SettingsScreen';
 import { MainTabParamList } from './types';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
@@ -31,6 +32,7 @@ export default function MainTabNavigator() {
     >
       <Tab.Screen name="Feed" component={FeedScreen} options={{ title: t('tabs.feed') }} />
       <Tab.Screen name="Friends" component={FriendsScreen} options={{ title: t('tabs.friends') }} />
+      <Tab.Screen name="Shelf" component={ShelfScreen} options={{ title: t('tabs.shelf') }} />
       <Tab.Screen name="Settings" component={SettingsScreen} options={{ title: t('tabs.settings') }} />
     </Tab.Navigator>
   );

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,7 @@ export type RootStackParamList = {
 export type MainTabParamList = {
   Feed: undefined;
   Friends: undefined;
+  Shelf: undefined;
   Settings: undefined;
 };
 

--- a/src/screens/ShelfScreen.test.tsx
+++ b/src/screens/ShelfScreen.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import ShelfScreen from './ShelfScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'user1' }, loading: false }),
+}));
+
+jest.mock('@/lib/books/readingActivity', () => ({
+  subscribeToReadingActivities: jest.fn(() => jest.fn()),
+}));
+
+import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
+const mockSubscribe = subscribeToReadingActivities as jest.Mock;
+
+describe('ShelfScreen', () => {
+  beforeEach(() => {
+    mockSubscribe.mockClear();
+    mockSubscribe.mockReturnValue(jest.fn());
+  });
+
+  it('renders the Currently Reading section header', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.currentlyReading')).toBeTruthy();
+  });
+
+  it('renders the Finished section header', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.finished')).toBeTruthy();
+  });
+
+  it('shows empty state when no activities in Currently Reading', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.emptyCurrentlyReading')).toBeTruthy();
+  });
+
+  it('always shows empty state in Finished section', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.emptyFinished')).toBeTruthy();
+  });
+
+  it('subscribes to activities for the current user on mount', () => {
+    render(<ShelfScreen />);
+    expect(mockSubscribe).toHaveBeenCalledWith('user1', expect.any(Function));
+  });
+
+  it('renders book title when activities exist', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([
+        {
+          id: 'act1',
+          userId: 'user1',
+          bookId: 'book123',
+          title: 'The Great Gatsby',
+          authors: ['F. Scott Fitzgerald'],
+          thumbnail: null,
+          startedAt: null,
+        },
+      ]);
+      return jest.fn();
+    });
+    render(<ShelfScreen />);
+    expect(screen.getByText('The Great Gatsby')).toBeTruthy();
+  });
+
+  it('renders author when activities exist', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([
+        {
+          id: 'act1',
+          userId: 'user1',
+          bookId: 'book123',
+          title: 'The Great Gatsby',
+          authors: ['F. Scott Fitzgerald'],
+          thumbnail: null,
+          startedAt: null,
+        },
+      ]);
+      return jest.fn();
+    });
+    render(<ShelfScreen />);
+    expect(screen.getByText('F. Scott Fitzgerald')).toBeTruthy();
+  });
+
+  it('hides empty Currently Reading state when activities exist', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([
+        {
+          id: 'act1',
+          userId: 'user1',
+          bookId: 'book123',
+          title: 'Dune',
+          authors: ['Frank Herbert'],
+          thumbnail: null,
+          startedAt: null,
+        },
+      ]);
+      return jest.fn();
+    });
+    render(<ShelfScreen />);
+    expect(screen.queryByText('shelf.emptyCurrentlyReading')).toBeNull();
+  });
+
+  it('thumbnail image has an accessibilityLabel matching the book title', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([
+        {
+          id: 'act1',
+          userId: 'user1',
+          bookId: 'book123',
+          title: 'Accessible Book',
+          authors: ['Author'],
+          thumbnail: 'https://example.com/cover.jpg',
+          startedAt: null,
+        },
+      ]);
+      return jest.fn();
+    });
+    render(<ShelfScreen />);
+    expect(screen.getByLabelText('Accessible Book')).toBeTruthy();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const mockUnsubscribe = jest.fn();
+    mockSubscribe.mockReturnValue(mockUnsubscribe);
+    const { unmount } = render(<ShelfScreen />);
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ScrollView, Image, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import ScreenContainer from '@/components/layout/ScreenContainer';
+import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
+import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
+import { useAuth } from '@/hooks/useAuth';
+import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
+import type { ReadingActivity } from '@/lib/books/readingActivity';
+
+export default function ShelfScreen() {
+  const { t } = useTranslation();
+  const tabBarInset = useGlassTabBarInset();
+  const { user } = useAuth();
+  const [activities, setActivities] = useState<ReadingActivity[]>([]);
+
+  useEffect(() => {
+    const uid = user?.uid;
+    if (!uid) return;
+    const unsubscribe = subscribeToReadingActivities(uid, setActivities);
+    return unsubscribe;
+  }, [user?.uid]);
+
+  return (
+    <ScreenContainer bottomInset={tabBarInset}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <Text style={styles.sectionHeader}>{t('shelf.currentlyReading')}</Text>
+        {activities.length === 0 ? (
+          <Text style={styles.emptyText}>{t('shelf.emptyCurrentlyReading')}</Text>
+        ) : (
+          activities.map((item) => (
+            <View key={item.id} style={styles.card}>
+              {item.thumbnail ? (
+                <Image
+                  source={{ uri: item.thumbnail }}
+                  style={styles.thumbnail}
+                  accessibilityLabel={item.title}
+                />
+              ) : (
+                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]} />
+              )}
+              <View style={styles.cardInfo}>
+                <Text style={styles.bookTitle}>{item.title}</Text>
+                <Text style={styles.author}>{item.authors.join(', ')}</Text>
+                {item.startedAt && (
+                  <Text style={styles.date}>{item.startedAt.toDate().toLocaleDateString()}</Text>
+                )}
+              </View>
+            </View>
+          ))
+        )}
+
+        <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced]}>{t('shelf.finished')}</Text>
+        <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
+      </ScrollView>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingTop: 16,
+    paddingBottom: 16,
+  },
+  sectionHeader: {
+    fontSize: yomoyoTypography.screenTitleSize,
+    fontWeight: yomoyoTypography.titleWeight,
+    color: yomoyoColors.text,
+    marginBottom: 12,
+  },
+  sectionHeaderSpaced: {
+    marginTop: 32,
+  },
+  emptyText: {
+    fontSize: yomoyoTypography.screenBodySize,
+    color: yomoyoColors.muted,
+    marginBottom: 8,
+  },
+  card: {
+    flexDirection: 'row',
+    backgroundColor: yomoyoColors.surface,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    shadowColor: yomoyoColors.text,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  thumbnail: {
+    width: 52,
+    height: 72,
+    borderRadius: 6,
+    marginRight: 12,
+  },
+  thumbnailPlaceholder: {
+    backgroundColor: yomoyoColors.border,
+  },
+  cardInfo: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  bookTitle: {
+    fontSize: yomoyoTypography.screenBodySize,
+    fontWeight: yomoyoTypography.buttonWeight,
+    color: yomoyoColors.text,
+    marginBottom: 4,
+  },
+  author: {
+    fontSize: 14,
+    color: yomoyoColors.secondaryText,
+    marginBottom: 4,
+  },
+  date: {
+    fontSize: 13,
+    color: yomoyoColors.muted,
+  },
+});


### PR DESCRIPTION
- Add ShelfScreen with two sections: currently reading and finished
- Subscribe to readingActivities for the logged-in user
- Show empty states for both sections (finished is always empty until status field is added)
- Add Shelf as 4th tab in MainTabNavigator with library icon
- Add shelf i18n strings in en and ja locales
- Add accessibilityLabel to book cover thumbnails