### PR TITLE
refactor: remove started-reading flow and currently-reading state

### DIFF
--- a/src/lib/books/readingActivity.test.ts
+++ b/src/lib/books/readingActivity.test.ts
@@ -1,11 +1,10 @@
-import { startReading, markAsFinished, subscribeToReadingActivities } from './readingActivity';
+import { markAsFinished, subscribeToReadingActivities } from './readingActivity';
 import type { Book } from './searchBooks';
 
 import {
   collection,
   doc,
   setDoc,
-  updateDoc,
   query,
   where,
   orderBy,
@@ -24,19 +23,24 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('startReading', () => {
+describe('markAsFinished', () => {
   it('writes to the readingActivities path', async () => {
-    await startReading('user1', book);
+    await markAsFinished('user1', book);
     expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'readingActivities', expect.any(String));
   });
 
   it('uses a deterministic doc ID derived from userId and bookId', async () => {
-    await startReading('user1', book);
+    await markAsFinished('user1', book);
     expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'readingActivities', 'user1_book123');
   });
 
-  it('stores userId, bookId, title, authors, thumbnail, startedAt, and status', async () => {
-    await startReading('user1', book);
+  it('calls setDoc (not updateDoc)', async () => {
+    await markAsFinished('user1', book);
+    expect(jest.mocked(setDoc)).toHaveBeenCalled();
+  });
+
+  it('stores userId, bookId, title, authors, thumbnail, finishedAt, and status finished', async () => {
+    await markAsFinished('user1', book);
     expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
       expect.anything(),
       {
@@ -45,53 +49,27 @@ describe('startReading', () => {
         title: 'The Great Gatsby',
         authors: ['F. Scott Fitzgerald'],
         thumbnail: 'https://example.com/cover.jpg',
-        startedAt: expect.anything(),
-        status: 'reading',
+        finishedAt: expect.anything(),
+        status: 'finished',
       },
     );
   });
 
   it('stores null thumbnail when book has no cover', async () => {
-    await startReading('user1', { ...book, thumbnail: null });
+    await markAsFinished('user1', { ...book, thumbnail: null });
     expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ thumbnail: null }),
     );
   });
 
-  it('uses serverTimestamp for startedAt', async () => {
-    await startReading('user1', book);
+  it('uses serverTimestamp for finishedAt', async () => {
+    await markAsFinished('user1', book);
     expect(jest.mocked(serverTimestamp)).toHaveBeenCalled();
   });
 
   it('resolves without error', async () => {
-    await expect(startReading('user1', book)).resolves.toBeUndefined();
-  });
-});
-
-describe('markAsFinished', () => {
-  it('writes to the correct doc path using userId and bookId', async () => {
-    await markAsFinished('user1', 'book123');
-    expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'readingActivities', 'user1_book123');
-  });
-
-  it('calls updateDoc (not setDoc)', async () => {
-    await markAsFinished('user1', 'book123');
-    expect(jest.mocked(updateDoc)).toHaveBeenCalled();
-    expect(jest.mocked(setDoc)).not.toHaveBeenCalled();
-  });
-
-  it('sets status to finished and finishedAt to serverTimestamp', async () => {
-    await markAsFinished('user1', 'book123');
-    expect(jest.mocked(updateDoc)).toHaveBeenCalledWith(
-      expect.anything(),
-      { status: 'finished', finishedAt: expect.anything() },
-    );
-    expect(jest.mocked(serverTimestamp)).toHaveBeenCalled();
-  });
-
-  it('resolves without error', async () => {
-    await expect(markAsFinished('user1', 'book123')).resolves.toBeUndefined();
+    await expect(markAsFinished('user1', book)).resolves.toBeUndefined();
   });
 });
 
@@ -102,9 +80,14 @@ describe('subscribeToReadingActivities', () => {
     expect(jest.mocked(where)).toHaveBeenCalledWith('userId', '==', 'user1');
   });
 
-  it('orders results by startedAt descending', () => {
+  it('filters to only finished activities', () => {
     subscribeToReadingActivities('user1', jest.fn());
-    expect(jest.mocked(orderBy)).toHaveBeenCalledWith('startedAt', 'desc');
+    expect(jest.mocked(where)).toHaveBeenCalledWith('status', '==', 'finished');
+  });
+
+  it('orders results by finishedAt descending', () => {
+    subscribeToReadingActivities('user1', jest.fn());
+    expect(jest.mocked(orderBy)).toHaveBeenCalledWith('finishedAt', 'desc');
   });
 
   it('calls onUpdate with mapped activities when snapshot arrives', () => {
@@ -119,7 +102,8 @@ describe('subscribeToReadingActivities', () => {
               title: 'The Great Gatsby',
               authors: ['F. Scott Fitzgerald'],
               thumbnail: 'https://example.com/cover.jpg',
-              startedAt: null,
+              status: 'finished',
+              finishedAt: null,
             }),
           },
         ],
@@ -138,7 +122,8 @@ describe('subscribeToReadingActivities', () => {
         title: 'The Great Gatsby',
         authors: ['F. Scott Fitzgerald'],
         thumbnail: 'https://example.com/cover.jpg',
-        startedAt: null,
+        status: 'finished',
+        finishedAt: null,
       },
     ]);
   });

--- a/src/lib/books/readingActivity.ts
+++ b/src/lib/books/readingActivity.ts
@@ -3,7 +3,6 @@ import {
   collection,
   doc,
   setDoc,
-  updateDoc,
   query,
   where,
   orderBy,
@@ -12,7 +11,6 @@ import {
 } from 'firebase/firestore';
 import type { Book } from './searchBooks';
 
-// Minimal Firestore Timestamp shape needed for reading activity
 type FirestoreTimestamp = { toMillis: () => number; toDate: () => Date };
 
 export type ReadingActivity = {
@@ -22,14 +20,12 @@ export type ReadingActivity = {
   title: string;
   authors: string[];
   thumbnail: string | null;
-  startedAt: FirestoreTimestamp | null;
-  status?: 'reading' | 'finished';
-  finishedAt?: FirestoreTimestamp | null;
+  status: 'finished';
+  finishedAt: FirestoreTimestamp | null;
 };
 
-export async function startReading(userId: string, book: Book): Promise<void> {
+export async function markAsFinished(userId: string, book: Book): Promise<void> {
   const db = getFirestore();
-  // Deterministic doc ID prevents duplicate records for the same user+book
   const docRef = doc(db, 'readingActivities', `${userId}_${book.id}`);
   await setDoc(docRef, {
     userId,
@@ -37,17 +33,8 @@ export async function startReading(userId: string, book: Book): Promise<void> {
     title: book.title,
     authors: book.authors,
     thumbnail: book.thumbnail,
-    startedAt: serverTimestamp(),
-    status: 'reading',
-  });
-}
-
-export async function markAsFinished(userId: string, bookId: string): Promise<void> {
-  const db = getFirestore();
-  const docRef = doc(db, 'readingActivities', `${userId}_${bookId}`);
-  await updateDoc(docRef, {
-    status: 'finished',
     finishedAt: serverTimestamp(),
+    status: 'finished',
   });
 }
 
@@ -60,7 +47,8 @@ export function subscribeToReadingActivities(
   const q = query(
     collection(db, 'readingActivities'),
     where('userId', '==', userId),
-    orderBy('startedAt', 'desc'),
+    where('status', '==', 'finished'),
+    orderBy('finishedAt', 'desc'),
   );
   return onSnapshot(
     q,

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -9,7 +9,6 @@ const en = {
     searchBooks: 'Search books',
     emptyTitle: 'Your reading feed is quiet',
     emptyBody: 'When friends finish books, their notes will appear here.',
-    startedReading: 'Started reading',
     finishedReading: 'Finished reading',
   },
   friends: {
@@ -26,13 +25,9 @@ const en = {
   },
   bookDetail: {
     unknownAuthor: 'Unknown author',
-    startReading: 'Start Reading',
-    reading: 'Reading',
   },
   shelf: {
-    currentlyReading: 'Currently Reading',
     finished: 'Finished',
-    emptyCurrentlyReading: 'No books currently reading',
     emptyFinished: 'No finished books yet',
     markAsFinished: 'Mark as Finished',
   },

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -9,7 +9,6 @@ const ja = {
     searchBooks: '本を探す',
     emptyTitle: '読書フィードは、まだ静かです',
     emptyBody: '友だちが本を読み終えると、ここにお便りが届きます。',
-    startedReading: '読み始めました',
     finishedReading: '読み終えました',
   },
   friends: {
@@ -26,13 +25,9 @@ const ja = {
   },
   bookDetail: {
     unknownAuthor: '著者不明',
-    startReading: '読み始める',
-    reading: '読書中',
   },
   shelf: {
-    currentlyReading: '読書中',
     finished: '読了',
-    emptyCurrentlyReading: '読書中の本はまだありません',
     emptyFinished: '読了した本はまだありません',
     markAsFinished: '読了にする',
   },

--- a/src/screens/BookDetailScreen.test.tsx
+++ b/src/screens/BookDetailScreen.test.tsx
@@ -24,11 +24,11 @@ jest.mock('@/hooks/useAuth', () => ({
 }));
 
 jest.mock('@/lib/books/readingActivity', () => ({
-  startReading: jest.fn(() => Promise.resolve()),
+  markAsFinished: jest.fn(() => Promise.resolve()),
 }));
 
-import { startReading } from '@/lib/books/readingActivity';
-const mockStartReading = startReading as jest.Mock;
+import { markAsFinished } from '@/lib/books/readingActivity';
+const mockMarkAsFinished = markAsFinished as jest.Mock;
 
 describe('BookDetailScreen', () => {
   beforeEach(() => {
@@ -37,7 +37,7 @@ describe('BookDetailScreen', () => {
       key: 'BookDetail',
       name: 'BookDetail',
     });
-    mockStartReading.mockClear();
+    mockMarkAsFinished.mockClear();
   });
 
   it('renders the book title', () => {
@@ -75,33 +75,34 @@ describe('BookDetailScreen', () => {
     expect(screen.getByText('bookDetail.unknownAuthor')).toBeTruthy();
   });
 
-  it('renders the Start Reading button', () => {
+  it('renders the Mark as Finished button', () => {
     render(<BookDetailScreen />);
-    expect(screen.getByText('bookDetail.startReading')).toBeTruthy();
+    expect(screen.getByText('shelf.markAsFinished')).toBeTruthy();
   });
 
-  it('calls startReading with user uid and book when button is pressed', async () => {
+  it('calls markAsFinished with user uid and book when button is pressed', async () => {
     render(<BookDetailScreen />);
-    fireEvent.press(screen.getByText('bookDetail.startReading'));
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
     await waitFor(() => {
-      expect(mockStartReading).toHaveBeenCalledWith('user1', mockBook);
+      expect(mockMarkAsFinished).toHaveBeenCalledWith('user1', mockBook);
     });
   });
 
-  it('shows Reading label after successfully pressing the button', async () => {
+  it('shows Finished label and disables button after success', async () => {
     render(<BookDetailScreen />);
-    fireEvent.press(screen.getByText('bookDetail.startReading'));
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
     await waitFor(() => {
-      expect(screen.getByText('bookDetail.reading')).toBeTruthy();
+      expect(screen.getByText('shelf.finished')).toBeTruthy();
     });
+    expect(screen.getByRole('button').props.accessibilityState?.disabled).toBe(true);
   });
 
-  it('returns to Start Reading label so the user can retry on failure', async () => {
-    mockStartReading.mockRejectedValueOnce(new Error('network error'));
+  it('returns to Mark as Finished label so the user can retry on failure', async () => {
+    mockMarkAsFinished.mockRejectedValueOnce(new Error('network error'));
     render(<BookDetailScreen />);
-    fireEvent.press(screen.getByText('bookDetail.startReading'));
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
     await waitFor(() => {
-      expect(screen.getByText('bookDetail.startReading')).toBeTruthy();
+      expect(screen.getByText('shelf.markAsFinished')).toBeTruthy();
     });
   });
 });

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import type { RootStackParamList } from '@/navigation/types';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { useAuth } from '@/hooks/useAuth';
-import { startReading } from '@/lib/books/readingActivity';
+import { markAsFinished } from '@/lib/books/readingActivity';
 
 type RouteType = RouteProp<RootStackParamList, 'BookDetail'>;
 
@@ -22,15 +22,15 @@ export default function BookDetailScreen() {
   const route = useRoute<RouteType>();
   const { book } = route.params;
   const { user } = useAuth();
-  const [hasStarted, setHasStarted] = useState(false);
+  const [hasFinished, setHasFinished] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleStartReading = async () => {
-    if (!user || isLoading || hasStarted) return;
+  const handleMarkAsFinished = async () => {
+    if (!user || isLoading || hasFinished) return;
     setIsLoading(true);
     try {
-      await startReading(user.uid, book);
-      setHasStarted(true);
+      await markAsFinished(user.uid, book);
+      setHasFinished(true);
     } catch {
       // Write failed — button returns to idle so the user can retry
     } finally {
@@ -52,13 +52,13 @@ export default function BookDetailScreen() {
         {book.authors.length > 0 ? book.authors.join(', ') : t('bookDetail.unknownAuthor')}
       </Text>
       <TouchableOpacity
-        style={[styles.button, (hasStarted || isLoading) && styles.buttonDone]}
-        onPress={handleStartReading}
-        disabled={hasStarted || isLoading}
+        style={[styles.button, (hasFinished || isLoading) && styles.buttonDone]}
+        onPress={handleMarkAsFinished}
+        disabled={hasFinished || isLoading}
         accessibilityRole="button"
       >
         <Text style={styles.buttonText}>
-          {hasStarted ? t('bookDetail.reading') : t('bookDetail.startReading')}
+          {hasFinished ? t('shelf.finished') : t('shelf.markAsFinished')}
         </Text>
       </TouchableOpacity>
     </ScrollView>

--- a/src/screens/FeedScreen.test.tsx
+++ b/src/screens/FeedScreen.test.tsx
@@ -76,6 +76,8 @@ describe('FeedScreen', () => {
           title: 'The Great Gatsby',
           authors: ['F. Scott Fitzgerald'],
           thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
         },
       ]);
       return jest.fn();
@@ -85,7 +87,7 @@ describe('FeedScreen', () => {
     expect(screen.getByText('The Great Gatsby')).toBeTruthy();
   });
 
-  it('shows startedReading label for each activity', () => {
+  it('shows finishedReading label for all activity cards', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
       onUpdate([
         {
@@ -95,13 +97,16 @@ describe('FeedScreen', () => {
           title: 'Dune',
           authors: ['Frank Herbert'],
           thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
         },
       ]);
       return jest.fn();
     });
 
     render(<FeedScreen />);
-    expect(screen.getByText('feed.startedReading')).toBeTruthy();
+    expect(screen.getByText('feed.finishedReading')).toBeTruthy();
+    expect(screen.queryByText('feed.startedReading')).toBeNull();
   });
 
   it('hides empty state when activities are present', () => {
@@ -114,6 +119,8 @@ describe('FeedScreen', () => {
           title: 'Dune',
           authors: ['Frank Herbert'],
           thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
         },
       ]);
       return jest.fn();
@@ -131,66 +138,5 @@ describe('FeedScreen', () => {
     unmount();
 
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows finishedReading label for activities with status finished', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          status: 'finished',
-        },
-      ]);
-      return jest.fn();
-    });
-
-    render(<FeedScreen />);
-    expect(screen.getByText('feed.finishedReading')).toBeTruthy();
-    expect(screen.queryByText('feed.startedReading')).toBeNull();
-  });
-
-  it('shows startedReading label for activities with status reading', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-
-    render(<FeedScreen />);
-    expect(screen.getByText('feed.startedReading')).toBeTruthy();
-    expect(screen.queryByText('feed.finishedReading')).toBeNull();
-  });
-
-  it('shows startedReading label when status is absent', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-        },
-      ]);
-      return jest.fn();
-    });
-
-    render(<FeedScreen />);
-    expect(screen.getByText('feed.startedReading')).toBeTruthy();
   });
 });

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -38,7 +38,7 @@ export default function FeedScreen() {
           renderItem={({ item }) => (
             <View style={styles.card}>
               <Text style={styles.cardLabel}>
-                {item.status === 'finished' ? t('feed.finishedReading') : t('feed.startedReading')}
+                {t('feed.finishedReading')}
               </Text>
               <Text style={styles.cardTitle}>{item.title}</Text>
             </View>

--- a/src/screens/ShelfScreen.test.tsx
+++ b/src/screens/ShelfScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react-native';
+import { render, screen } from '@testing-library/react-native';
 import ShelfScreen from './ShelfScreen';
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -16,33 +16,36 @@ jest.mock('@/hooks/useAuth', () => ({
 
 jest.mock('@/lib/books/readingActivity', () => ({
   subscribeToReadingActivities: jest.fn(() => jest.fn()),
-  markAsFinished: jest.fn(() => Promise.resolve()),
 }));
 
-import { subscribeToReadingActivities, markAsFinished } from '@/lib/books/readingActivity';
+import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
 const mockSubscribe = subscribeToReadingActivities as jest.Mock;
-const mockMarkAsFinished = markAsFinished as jest.Mock;
+
+const finishedActivity = {
+  id: 'act1',
+  userId: 'user1',
+  bookId: 'book123',
+  title: 'The Great Gatsby',
+  authors: ['F. Scott Fitzgerald'],
+  thumbnail: null,
+  status: 'finished',
+  finishedAt: null,
+};
 
 describe('ShelfScreen', () => {
   beforeEach(() => {
     mockSubscribe.mockClear();
-    mockMarkAsFinished.mockClear();
     mockSubscribe.mockReturnValue(jest.fn());
   });
 
-  it('renders the Currently Reading section header', () => {
+  it('does not render the Currently Reading section', () => {
     render(<ShelfScreen />);
-    expect(screen.getByText('shelf.currentlyReading')).toBeTruthy();
+    expect(screen.queryByText('shelf.currentlyReading')).toBeNull();
   });
 
   it('renders the Finished section header', () => {
     render(<ShelfScreen />);
     expect(screen.getByText('shelf.finished')).toBeTruthy();
-  });
-
-  it('shows empty state when no activities in Currently Reading', () => {
-    render(<ShelfScreen />);
-    expect(screen.getByText('shelf.emptyCurrentlyReading')).toBeTruthy();
   });
 
   it('shows empty Finished state when no finished books exist', () => {
@@ -55,74 +58,40 @@ describe('ShelfScreen', () => {
     expect(mockSubscribe).toHaveBeenCalledWith('user1', expect.any(Function));
   });
 
-  it('renders book title when activities exist', () => {
+  it('renders book title when finished activities exist', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'The Great Gatsby',
-          authors: ['F. Scott Fitzgerald'],
-          thumbnail: null,
-          startedAt: null,
-        },
-      ]);
+      onUpdate([finishedActivity]);
       return jest.fn();
     });
     render(<ShelfScreen />);
     expect(screen.getByText('The Great Gatsby')).toBeTruthy();
   });
 
-  it('renders author when activities exist', () => {
+  it('renders author when finished activities exist', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'The Great Gatsby',
-          authors: ['F. Scott Fitzgerald'],
-          thumbnail: null,
-          startedAt: null,
-        },
-      ]);
+      onUpdate([finishedActivity]);
       return jest.fn();
     });
     render(<ShelfScreen />);
     expect(screen.getByText('F. Scott Fitzgerald')).toBeTruthy();
   });
 
-  it('hides empty Currently Reading state when activities exist', () => {
+  it('hides empty Finished state when finished activities exist', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          startedAt: null,
-        },
-      ]);
+      onUpdate([finishedActivity]);
       return jest.fn();
     });
     render(<ShelfScreen />);
-    expect(screen.queryByText('shelf.emptyCurrentlyReading')).toBeNull();
+    expect(screen.queryByText('shelf.emptyFinished')).toBeNull();
   });
 
   it('thumbnail image has an accessibilityLabel matching the book title', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
       onUpdate([
         {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
+          ...finishedActivity,
           title: 'Accessible Book',
-          authors: ['Author'],
           thumbnail: 'https://example.com/cover.jpg',
-          startedAt: null,
         },
       ]);
       return jest.fn();
@@ -139,157 +108,12 @@ describe('ShelfScreen', () => {
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('shows Mark as Finished button for each currently reading book', () => {
+  it('does not show a Mark as Finished button', () => {
     mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    expect(screen.getByText('shelf.markAsFinished')).toBeTruthy();
-  });
-
-  it('calls markAsFinished with userId and bookId when button is pressed', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    fireEvent.press(screen.getByText('shelf.markAsFinished'));
-    expect(mockMarkAsFinished).toHaveBeenCalledWith('user1', 'book123');
-  });
-
-  it('renders finished books in the Finished section', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book456',
-          title: 'Finished Book',
-          authors: ['Author'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'finished',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    expect(screen.getByText('Finished Book')).toBeTruthy();
-    expect(screen.queryByText('shelf.emptyFinished')).toBeNull();
-  });
-
-  it('does not show finished books in Currently Reading', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book456',
-          title: 'Finished Book',
-          authors: ['Author'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'finished',
-        },
-      ]);
+      onUpdate([finishedActivity]);
       return jest.fn();
     });
     render(<ShelfScreen />);
     expect(screen.queryByText('shelf.markAsFinished')).toBeNull();
-    expect(screen.getByText('shelf.emptyCurrentlyReading')).toBeTruthy();
-  });
-
-  it('does not show currently reading books in the Finished section', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Reading Book',
-          authors: ['Author'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    expect(screen.getByText('shelf.emptyFinished')).toBeTruthy();
-  });
-
-  it('does not crash when markAsFinished rejects', async () => {
-    mockMarkAsFinished.mockRejectedValueOnce(new Error('network error'));
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    await act(async () => {
-      fireEvent.press(screen.getByText('shelf.markAsFinished'));
-    });
-    expect(screen.getByText('Dune')).toBeTruthy();
-  });
-
-  it('logs error to console.error when markAsFinished rejects', async () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const error = new Error('network error');
-    mockMarkAsFinished.mockRejectedValueOnce(error);
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          startedAt: null,
-          status: 'reading',
-        },
-      ]);
-      return jest.fn();
-    });
-    render(<ShelfScreen />);
-    await act(async () => {
-      fireEvent.press(screen.getByText('shelf.markAsFinished'));
-    });
-    expect(consoleError).toHaveBeenCalledWith('Failed to mark as finished:', error);
-    consoleError.mockRestore();
   });
 });

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, ScrollView, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Image, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { useAuth } from '@/hooks/useAuth';
-import { subscribeToReadingActivities, markAsFinished } from '@/lib/books/readingActivity';
+import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
 
 export default function ShelfScreen() {
@@ -21,54 +21,14 @@ export default function ShelfScreen() {
     return unsubscribe;
   }, [user?.uid]);
 
-  const currentlyReading = activities.filter((a) => a.status !== 'finished');
-  const finished = activities.filter((a) => a.status === 'finished');
-
   return (
     <ScreenContainer bottomInset={tabBarInset}>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-        <Text style={styles.sectionHeader}>{t('shelf.currentlyReading')}</Text>
-        {currentlyReading.length === 0 ? (
-          <Text style={styles.emptyText}>{t('shelf.emptyCurrentlyReading')}</Text>
-        ) : (
-          currentlyReading.map((item) => (
-            <View key={item.id} style={styles.card}>
-              {item.thumbnail ? (
-                <Image
-                  source={{ uri: item.thumbnail }}
-                  style={styles.thumbnail}
-                  accessibilityLabel={item.title}
-                />
-              ) : (
-                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]} />
-              )}
-              <View style={styles.cardInfo}>
-                <Text style={styles.bookTitle}>{item.title}</Text>
-                <Text style={styles.author}>{item.authors.join(', ')}</Text>
-                {item.startedAt && (
-                  <Text style={styles.date}>{item.startedAt.toDate().toLocaleDateString()}</Text>
-                )}
-                <TouchableOpacity
-                  onPress={() => {
-                    markAsFinished(item.userId, item.bookId).catch((err) => {
-                      console.error('Failed to mark as finished:', err);
-                    });
-                  }}
-                  accessibilityRole="button"
-                  style={styles.finishButton}
-                >
-                  <Text style={styles.finishButtonText}>{t('shelf.markAsFinished')}</Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-          ))
-        )}
-
-        <Text style={[styles.sectionHeader, styles.sectionHeaderSpaced]}>{t('shelf.finished')}</Text>
-        {finished.length === 0 ? (
+        <Text style={styles.sectionHeader}>{t('shelf.finished')}</Text>
+        {activities.length === 0 ? (
           <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
         ) : (
-          finished.map((item) => (
+          activities.map((item) => (
             <View key={item.id} style={styles.card}>
               {item.thumbnail ? (
                 <Image
@@ -104,9 +64,6 @@ const styles = StyleSheet.create({
     fontWeight: yomoyoTypography.titleWeight,
     color: yomoyoColors.text,
     marginBottom: 12,
-  },
-  sectionHeaderSpaced: {
-    marginTop: 32,
   },
   emptyText: {
     fontSize: yomoyoTypography.screenBodySize,
@@ -152,14 +109,5 @@ const styles = StyleSheet.create({
   date: {
     fontSize: 13,
     color: yomoyoColors.muted,
-  },
-  finishButton: {
-    marginTop: 8,
-    alignSelf: 'flex-start',
-  },
-  finishButtonText: {
-    fontSize: 13,
-    color: yomoyoColors.primary,
-    fontWeight: yomoyoTypography.buttonWeight,
   },
 });


### PR DESCRIPTION
Only finishing a book now creates a record and posts to the feed.
- Remove startReading() and all reading/currently-reading logic
- markAsFinished() now takes a Book object and uses setDoc directly
- Subscription filters to status=finished and orders by finishedAt
- ShelfScreen shows only the Finished section
- BookDetailScreen replaces Start Reading with Mark as Finished
- Remove unused i18n keys for startedReading, currentlyReading, etc.

Closes #32