### PR TITLE
feat: implement friends' reading activity feed with infinite scroll

### DIFF
--- a/__mocks__/firebase/firestore.js
+++ b/__mocks__/firebase/firestore.js
@@ -3,8 +3,11 @@ const mockCollection = jest.fn(() => ({ type: 'collRef' }));
 const mockDoc = jest.fn(() => ({ type: 'docRef' }));
 const mockSetDoc = jest.fn(() => Promise.resolve());
 const mockUpdateDoc = jest.fn(() => Promise.resolve());
+const mockGetDocs = jest.fn(() => Promise.resolve({ docs: [] }));
 const mockWhere = jest.fn(() => ({ type: 'whereConstraint' }));
 const mockOrderBy = jest.fn(() => ({ type: 'orderByConstraint' }));
+const mockLimit = jest.fn(() => ({ type: 'limitConstraint' }));
+const mockStartAfter = jest.fn(() => ({ type: 'startAfterConstraint' }));
 const mockQuery = jest.fn((...args) => args[0]);
 const mockUnsubscribe = jest.fn();
 const mockOnSnapshot = jest.fn(() => mockUnsubscribe);
@@ -16,8 +19,11 @@ module.exports = {
   doc: mockDoc,
   setDoc: mockSetDoc,
   updateDoc: mockUpdateDoc,
+  getDocs: mockGetDocs,
   where: mockWhere,
   orderBy: mockOrderBy,
+  limit: mockLimit,
+  startAfter: mockStartAfter,
   query: mockQuery,
   onSnapshot: mockOnSnapshot,
   serverTimestamp: mockServerTimestamp,

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,10 +2,18 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /readingActivities/{docId} {
-      // Only the owning user can read or write their own activities
-      allow read: if request.auth != null && request.auth.uid == resource.data.userId;
+      // Any authenticated user can read activities (needed for the friends feed)
+      allow read: if request.auth != null;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
       allow update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+
+    match /follows/{docId} {
+      // Any authenticated user can read follows (needed to resolve the following list)
+      allow read: if request.auth != null;
+      // Only the follower can manage their own follow records
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.followerId;
+      allow delete: if request.auth != null && request.auth.uid == resource.data.followerId;
     }
   }
 }

--- a/src/lib/books/friendsFeed.test.ts
+++ b/src/lib/books/friendsFeed.test.ts
@@ -1,0 +1,102 @@
+import { getFriendsFeed } from './friendsFeed';
+import { collection, query, where, orderBy, limit, startAfter, getDocs } from 'firebase/firestore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getFriendsFeed', () => {
+  it('returns an empty page immediately when followedUids is empty', async () => {
+    const result = await getFriendsFeed([]);
+    expect(result).toEqual({ items: [], lastDoc: null });
+    expect(jest.mocked(getDocs)).not.toHaveBeenCalled();
+  });
+
+  it('queries the readingActivities collection', async () => {
+    await getFriendsFeed(['uid1']);
+    expect(jest.mocked(collection)).toHaveBeenCalledWith(expect.anything(), 'readingActivities');
+  });
+
+  it('filters by userId in the given uids', async () => {
+    await getFriendsFeed(['uid1', 'uid2']);
+    expect(jest.mocked(where)).toHaveBeenCalledWith('userId', 'in', ['uid1', 'uid2']);
+  });
+
+  it('orders results by finishedAt descending', async () => {
+    await getFriendsFeed(['uid1']);
+    expect(jest.mocked(orderBy)).toHaveBeenCalledWith('finishedAt', 'desc');
+  });
+
+  it('applies a default limit of 20', async () => {
+    await getFriendsFeed(['uid1']);
+    expect(jest.mocked(limit)).toHaveBeenCalledWith(20);
+  });
+
+  it('applies a custom page size when provided', async () => {
+    await getFriendsFeed(['uid1'], null, 5);
+    expect(jest.mocked(limit)).toHaveBeenCalledWith(5);
+  });
+
+  it('does not call startAfter when cursor is null', async () => {
+    await getFriendsFeed(['uid1'], null);
+    expect(jest.mocked(startAfter)).not.toHaveBeenCalled();
+  });
+
+  it('calls startAfter with the cursor when provided', async () => {
+    const mockCursor = { id: 'cursor-doc' };
+    await getFriendsFeed(['uid1'], mockCursor as any);
+    expect(jest.mocked(startAfter)).toHaveBeenCalledWith(mockCursor);
+  });
+
+  it('maps docs to items with id', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'act1',
+          data: () => ({
+            userId: 'user2',
+            bookId: 'book1',
+            title: 'Dune',
+            authors: ['Frank Herbert'],
+            thumbnail: null,
+            status: 'finished',
+            finishedAt: null,
+            displayLabel: 'Alice',
+            displayAvatar: null,
+          }),
+        },
+      ],
+    } as any);
+
+    const result = await getFriendsFeed(['user2']);
+    expect(result.items).toEqual([
+      {
+        id: 'act1',
+        userId: 'user2',
+        bookId: 'book1',
+        title: 'Dune',
+        authors: ['Frank Herbert'],
+        thumbnail: null,
+        status: 'finished',
+        finishedAt: null,
+        displayLabel: 'Alice',
+        displayAvatar: null,
+      },
+    ]);
+  });
+
+  it('returns lastDoc as the last document snapshot', async () => {
+    const mockDoc = { id: 'act1', data: () => ({}) };
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [mockDoc] } as any);
+
+    const result = await getFriendsFeed(['user2']);
+    expect(result.lastDoc).toBe(mockDoc);
+  });
+
+  it('returns lastDoc as null when no docs are returned', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+
+    const result = await getFriendsFeed(['user2']);
+    expect(result.lastDoc).toBeNull();
+  });
+});

--- a/src/lib/books/friendsFeed.ts
+++ b/src/lib/books/friendsFeed.ts
@@ -1,0 +1,43 @@
+import {
+  getFirestore,
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  startAfter,
+  getDocs,
+} from 'firebase/firestore';
+import type { QueryDocumentSnapshot } from 'firebase/firestore';
+import type { ReadingActivity } from './readingActivity';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export type FeedPage = {
+  items: ReadingActivity[];
+  lastDoc: QueryDocumentSnapshot | null;
+};
+
+export async function getFriendsFeed(
+  followedUids: string[],
+  cursor: QueryDocumentSnapshot | null = null,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): Promise<FeedPage> {
+  if (followedUids.length === 0) return { items: [], lastDoc: null };
+
+  const db = getFirestore();
+  const baseQuery = query(
+    collection(db, 'readingActivities'),
+    where('userId', 'in', followedUids),
+    orderBy('finishedAt', 'desc'),
+    limit(pageSize),
+  );
+  const q = cursor ? query(baseQuery, startAfter(cursor)) : baseQuery;
+  const snapshot = await getDocs(q);
+  const items: ReadingActivity[] = snapshot.docs.map((d) => ({
+    id: d.id,
+    ...(d.data() as Omit<ReadingActivity, 'id'>),
+  }));
+  const lastDoc = (snapshot.docs[snapshot.docs.length - 1] as QueryDocumentSnapshot) ?? null;
+  return { items, lastDoc };
+}

--- a/src/lib/books/readingActivity.test.ts
+++ b/src/lib/books/readingActivity.test.ts
@@ -19,28 +19,33 @@ const book: Book = {
   thumbnail: 'https://example.com/cover.jpg',
 };
 
+const presenter = {
+  displayLabel: 'Alice',
+  displayAvatar: 'https://example.com/avatar.jpg',
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe('markAsFinished', () => {
   it('writes to the readingActivities path', async () => {
-    await markAsFinished('user1', book);
+    await markAsFinished('user1', book, presenter);
     expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'readingActivities', expect.any(String));
   });
 
   it('uses a deterministic doc ID derived from userId and bookId', async () => {
-    await markAsFinished('user1', book);
+    await markAsFinished('user1', book, presenter);
     expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'readingActivities', 'user1_book123');
   });
 
   it('calls setDoc (not updateDoc)', async () => {
-    await markAsFinished('user1', book);
+    await markAsFinished('user1', book, presenter);
     expect(jest.mocked(setDoc)).toHaveBeenCalled();
   });
 
-  it('stores userId, bookId, title, authors, thumbnail, finishedAt, and status finished', async () => {
-    await markAsFinished('user1', book);
+  it('stores all book fields, presenter fields, finishedAt, and status', async () => {
+    await markAsFinished('user1', book, presenter);
     expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
       expect.anything(),
       {
@@ -51,25 +56,35 @@ describe('markAsFinished', () => {
         thumbnail: 'https://example.com/cover.jpg',
         finishedAt: expect.anything(),
         status: 'finished',
+        displayLabel: 'Alice',
+        displayAvatar: 'https://example.com/avatar.jpg',
       },
     );
   });
 
   it('stores null thumbnail when book has no cover', async () => {
-    await markAsFinished('user1', { ...book, thumbnail: null });
+    await markAsFinished('user1', { ...book, thumbnail: null }, presenter);
     expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ thumbnail: null }),
     );
   });
 
+  it('stores null displayAvatar when presenter has no avatar', async () => {
+    await markAsFinished('user1', book, { displayLabel: 'Alice', displayAvatar: null });
+    expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ displayAvatar: null }),
+    );
+  });
+
   it('uses serverTimestamp for finishedAt', async () => {
-    await markAsFinished('user1', book);
+    await markAsFinished('user1', book, presenter);
     expect(jest.mocked(serverTimestamp)).toHaveBeenCalled();
   });
 
   it('resolves without error', async () => {
-    await expect(markAsFinished('user1', book)).resolves.toBeUndefined();
+    await expect(markAsFinished('user1', book, presenter)).resolves.toBeUndefined();
   });
 });
 
@@ -104,6 +119,8 @@ describe('subscribeToReadingActivities', () => {
               thumbnail: 'https://example.com/cover.jpg',
               status: 'finished',
               finishedAt: null,
+              displayLabel: 'Alice',
+              displayAvatar: null,
             }),
           },
         ],
@@ -124,6 +141,8 @@ describe('subscribeToReadingActivities', () => {
         thumbnail: 'https://example.com/cover.jpg',
         status: 'finished',
         finishedAt: null,
+        displayLabel: 'Alice',
+        displayAvatar: null,
       },
     ]);
   });

--- a/src/lib/books/readingActivity.ts
+++ b/src/lib/books/readingActivity.ts
@@ -22,9 +22,16 @@ export type ReadingActivity = {
   thumbnail: string | null;
   status: 'finished';
   finishedAt: FirestoreTimestamp | null;
+  displayLabel?: string;
+  displayAvatar?: string | null;
 };
 
-export async function markAsFinished(userId: string, book: Book): Promise<void> {
+export type Presenter = {
+  displayLabel: string;
+  displayAvatar: string | null;
+};
+
+export async function markAsFinished(userId: string, book: Book, presenter: Presenter): Promise<void> {
   const db = getFirestore();
   const docRef = doc(db, 'readingActivities', `${userId}_${book.id}`);
   await setDoc(docRef, {
@@ -35,6 +42,8 @@ export async function markAsFinished(userId: string, book: Book): Promise<void> 
     thumbnail: book.thumbnail,
     finishedAt: serverTimestamp(),
     status: 'finished',
+    displayLabel: presenter.displayLabel,
+    displayAvatar: presenter.displayAvatar,
   });
 }
 

--- a/src/lib/users/follows.test.ts
+++ b/src/lib/users/follows.test.ts
@@ -1,0 +1,37 @@
+import { getFollowingUids } from './follows';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getFollowingUids', () => {
+  it('queries the follows collection', async () => {
+    await getFollowingUids('user1');
+    expect(jest.mocked(collection)).toHaveBeenCalledWith(expect.anything(), 'follows');
+  });
+
+  it('filters by followerId', async () => {
+    await getFollowingUids('user1');
+    expect(jest.mocked(where)).toHaveBeenCalledWith('followerId', '==', 'user1');
+  });
+
+  it('returns an array of followedUid strings', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        { id: 'user1_user2', data: () => ({ followerId: 'user1', followedUid: 'user2' }) },
+        { id: 'user1_user3', data: () => ({ followerId: 'user1', followedUid: 'user3' }) },
+      ],
+    } as any);
+
+    const result = await getFollowingUids('user1');
+    expect(result).toEqual(['user2', 'user3']);
+  });
+
+  it('returns an empty array when the user follows nobody', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+
+    const result = await getFollowingUids('user1');
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/users/follows.ts
+++ b/src/lib/users/follows.ts
@@ -1,0 +1,8 @@
+import { getFirestore, collection, query, where, getDocs } from 'firebase/firestore';
+
+export async function getFollowingUids(userId: string): Promise<string[]> {
+  const db = getFirestore();
+  const q = query(collection(db, 'follows'), where('followerId', '==', userId));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => (d.data() as { followedUid: string }).followedUid);
+}

--- a/src/screens/BookDetailScreen.test.tsx
+++ b/src/screens/BookDetailScreen.test.tsx
@@ -20,7 +20,15 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: { uid: 'user1' }, loading: false }),
+  useAuth: () => ({
+    user: {
+      uid: 'user1',
+      displayName: 'Alice',
+      photoURL: 'https://example.com/avatar.jpg',
+      email: 'alice@example.com',
+    },
+    loading: false,
+  }),
 }));
 
 jest.mock('@/lib/books/readingActivity', () => ({
@@ -80,11 +88,36 @@ describe('BookDetailScreen', () => {
     expect(screen.getByText('shelf.markAsFinished')).toBeTruthy();
   });
 
-  it('calls markAsFinished with user uid and book when button is pressed', async () => {
+  it('calls markAsFinished with userId, book, and presenter when button is pressed', async () => {
     render(<BookDetailScreen />);
     fireEvent.press(screen.getByText('shelf.markAsFinished'));
     await waitFor(() => {
-      expect(mockMarkAsFinished).toHaveBeenCalledWith('user1', mockBook);
+      expect(mockMarkAsFinished).toHaveBeenCalledWith('user1', mockBook, {
+        displayLabel: 'Alice',
+        displayAvatar: 'https://example.com/avatar.jpg',
+      });
+    });
+  });
+
+  it('uses email prefix as displayLabel fallback when displayName is null', async () => {
+    jest.mock('@/hooks/useAuth', () => ({
+      useAuth: () => ({
+        user: {
+          uid: 'user1',
+          displayName: null,
+          photoURL: null,
+          email: 'alice@example.com',
+        },
+        loading: false,
+      }),
+    }));
+
+    render(<BookDetailScreen />);
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
+    await waitFor(() => {
+      expect(mockMarkAsFinished).toHaveBeenCalledWith('user1', mockBook, expect.objectContaining({
+        displayLabel: expect.any(String),
+      }));
     });
   });
 

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -14,6 +14,7 @@ import type { RootStackParamList } from '@/navigation/types';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { useAuth } from '@/hooks/useAuth';
 import { markAsFinished } from '@/lib/books/readingActivity';
+import type { Presenter } from '@/lib/books/readingActivity';
 
 type RouteType = RouteProp<RootStackParamList, 'BookDetail'>;
 
@@ -29,7 +30,11 @@ export default function BookDetailScreen() {
     if (!user || isLoading || hasFinished) return;
     setIsLoading(true);
     try {
-      await markAsFinished(user.uid, book);
+      const presenter: Presenter = {
+        displayLabel: user.displayName ?? user.email?.split('@')[0] ?? 'Reader',
+        displayAvatar: user.photoURL ?? null,
+      };
+      await markAsFinished(user.uid, book, presenter);
       setHasFinished(true);
     } catch {
       // Write failed — button returns to idle so the user can retry

--- a/src/screens/FeedScreen.test.tsx
+++ b/src/screens/FeedScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react-native';
 import FeedScreen from './FeedScreen';
 
 const mockNavigate = jest.fn();
@@ -21,122 +21,204 @@ jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: { uid: 'user1' }, loading: false }),
 }));
 
-jest.mock('@/lib/books/readingActivity', () => ({
-  subscribeToReadingActivities: jest.fn(() => jest.fn()),
+jest.mock('@/lib/users/follows', () => ({
+  getFollowingUids: jest.fn(() => Promise.resolve([])),
 }));
 
-import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
-const mockSubscribe = subscribeToReadingActivities as jest.Mock;
+jest.mock('@/lib/books/friendsFeed', () => ({
+  getFriendsFeed: jest.fn(() => Promise.resolve({ items: [], lastDoc: null })),
+}));
+
+import { getFollowingUids } from '@/lib/users/follows';
+import { getFriendsFeed } from '@/lib/books/friendsFeed';
+
+const mockGetFollowingUids = getFollowingUids as jest.Mock;
+const mockGetFriendsFeed = getFriendsFeed as jest.Mock;
+
+const mockActivity = {
+  id: 'act1',
+  userId: 'user2',
+  bookId: 'book1',
+  title: 'Dune',
+  authors: ['Frank Herbert'],
+  thumbnail: null,
+  status: 'finished' as const,
+  finishedAt: null,
+  displayLabel: 'Bob',
+  displayAvatar: null,
+};
 
 describe('FeedScreen', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    mockSubscribe.mockClear();
-    mockSubscribe.mockReturnValue(jest.fn());
+    mockGetFollowingUids.mockClear();
+    mockGetFriendsFeed.mockClear();
+    mockGetFollowingUids.mockResolvedValue([]);
+    mockGetFriendsFeed.mockResolvedValue({ items: [], lastDoc: null });
   });
 
-  it('renders the empty state title key when no activities', () => {
+  it('renders the empty state when the user follows nobody', async () => {
     render(<FeedScreen />);
-    expect(screen.getByText('feed.emptyTitle')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('feed.emptyTitle')).toBeTruthy();
+    });
   });
 
-  it('renders the empty state body key when no activities', () => {
+  it('renders the empty state body when following nobody', async () => {
     render(<FeedScreen />);
-    expect(screen.getByText('feed.emptyBody')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('feed.emptyBody')).toBeTruthy();
+    });
   });
 
-  it('shows a search books button when no activities', () => {
+  it('shows a search books button in the empty state', async () => {
     render(<FeedScreen />);
-    expect(screen.getByText('feed.searchBooks')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('feed.searchBooks')).toBeTruthy();
+    });
   });
 
-  it('navigates to BookSearch when the button is pressed', () => {
+  it('navigates to BookSearch when the search button is pressed', async () => {
     render(<FeedScreen />);
+    await waitFor(() => screen.getByText('feed.searchBooks'));
     fireEvent.press(screen.getByText('feed.searchBooks'));
     expect(mockNavigate).toHaveBeenCalledWith('BookSearch');
   });
 
-  it('the search books button has an accessible button role', () => {
+  it('fetches following UIDs for the current user on mount', async () => {
     render(<FeedScreen />);
-    expect(screen.getByRole('button', { name: 'feed.searchBooks' })).toBeTruthy();
+    await waitFor(() => {
+      expect(mockGetFollowingUids).toHaveBeenCalledWith('user1');
+    });
   });
 
-  it('subscribes to activities for the current user on mount', () => {
+  it('calls getFriendsFeed with followed UIDs when the user follows someone', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2', 'user3']);
     render(<FeedScreen />);
-    expect(mockSubscribe).toHaveBeenCalledWith('user1', expect.any(Function));
+    await waitFor(() => {
+      expect(mockGetFriendsFeed).toHaveBeenCalledWith(['user2', 'user3'], null);
+    });
   });
 
-  it('renders activity cards when activities are present', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'The Great Gatsby',
-          authors: ['F. Scott Fitzgerald'],
-          thumbnail: null,
-          status: 'finished',
-          finishedAt: null,
-        },
-      ]);
-      return jest.fn();
+  it('does not call getFriendsFeed when the user follows nobody', async () => {
+    mockGetFollowingUids.mockResolvedValue([]);
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(mockGetFollowingUids).toHaveBeenCalled();
+    });
+    expect(mockGetFriendsFeed).not.toHaveBeenCalled();
+  });
+
+  it('renders activity cards when friends have finished books', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.getByText('Dune')).toBeTruthy();
+    });
+  });
+
+  it('shows the displayLabel in each activity card', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.getByText('Bob')).toBeTruthy();
+    });
+  });
+
+  it('shows the finishedReading label in each activity card', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.getByText('feed.finishedReading')).toBeTruthy();
+    });
+  });
+
+  it('hides the empty state when activities are present', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.queryByText('feed.emptyTitle')).toBeNull();
+    });
+  });
+
+  it('loads more activities when the list end is reached', async () => {
+    const mockCursor = { id: 'cursor-doc' };
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed
+      .mockResolvedValueOnce({ items: [mockActivity], lastDoc: mockCursor })
+      .mockResolvedValueOnce({ items: [], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Dune'));
+
+    fireEvent(screen.getByTestId('friends-feed-list'), 'onEndReached');
+
+    await waitFor(() => {
+      expect(mockGetFriendsFeed).toHaveBeenCalledTimes(2);
+      expect(mockGetFriendsFeed).toHaveBeenNthCalledWith(2, ['user2'], mockCursor);
+    });
+  });
+
+  it('does not load more when there is no lastDoc', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Dune'));
+
+    fireEvent(screen.getByTestId('friends-feed-list'), 'onEndReached');
+
+    await waitFor(() => {
+      expect(mockGetFriendsFeed).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows empty state when getFollowingUids rejects', async () => {
+    mockGetFollowingUids.mockRejectedValueOnce(new Error('network error'));
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.getByText('feed.emptyTitle')).toBeTruthy();
+    });
+  });
+
+  it('shows empty state when getFriendsFeed rejects on initial load', async () => {
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed.mockRejectedValueOnce(new Error('network error'));
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(screen.getByText('feed.emptyTitle')).toBeTruthy();
+    });
+  });
+
+  it('allows retrying load more after getFriendsFeed rejects', async () => {
+    const mockCursor = { id: 'cursor-doc' };
+    mockGetFollowingUids.mockResolvedValue(['user2']);
+    mockGetFriendsFeed
+      .mockResolvedValueOnce({ items: [mockActivity], lastDoc: mockCursor })
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ items: [], lastDoc: null });
+
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Dune'));
+
+    // First load more — rejects
+    await act(async () => {
+      fireEvent(screen.getByTestId('friends-feed-list'), 'onEndReached');
     });
 
-    render(<FeedScreen />);
-    expect(screen.getByText('The Great Gatsby')).toBeTruthy();
-  });
-
-  it('shows finishedReading label for all activity cards', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          status: 'finished',
-          finishedAt: null,
-        },
-      ]);
-      return jest.fn();
+    // Second load more — should work because isLoadingMore was reset after failure
+    await act(async () => {
+      fireEvent(screen.getByTestId('friends-feed-list'), 'onEndReached');
     });
 
-    render(<FeedScreen />);
-    expect(screen.getByText('feed.finishedReading')).toBeTruthy();
-    expect(screen.queryByText('feed.startedReading')).toBeNull();
-  });
-
-  it('hides empty state when activities are present', () => {
-    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
-      onUpdate([
-        {
-          id: 'act1',
-          userId: 'user1',
-          bookId: 'book123',
-          title: 'Dune',
-          authors: ['Frank Herbert'],
-          thumbnail: null,
-          status: 'finished',
-          finishedAt: null,
-        },
-      ]);
-      return jest.fn();
-    });
-
-    render(<FeedScreen />);
-    expect(screen.queryByText('feed.emptyTitle')).toBeNull();
-  });
-
-  it('unsubscribes on unmount', () => {
-    const mockUnsubscribe = jest.fn();
-    mockSubscribe.mockReturnValue(mockUnsubscribe);
-
-    const { unmount } = render(<FeedScreen />);
-    unmount();
-
-    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockGetFriendsFeed).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -1,14 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, Text, FlatList, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
+import type { QueryDocumentSnapshot } from 'firebase/firestore';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import type { RootStackParamList } from '@/navigation/types';
 import { useAuth } from '@/hooks/useAuth';
-import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
+import { getFollowingUids } from '@/lib/users/follows';
+import { getFriendsFeed } from '@/lib/books/friendsFeed';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
@@ -18,28 +20,61 @@ export default function FeedScreen() {
   const { t } = useTranslation();
   const tabBarInset = useGlassTabBarInset();
   const { user } = useAuth();
-  const [activities, setActivities] = useState<ReadingActivity[]>([]);
 
-  const uid = user?.uid ?? null;
+  const [followingUids, setFollowingUids] = useState<string[]>([]);
+  const [items, setItems] = useState<ReadingActivity[]>([]);
+  const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
-    if (!uid) return;
-    const unsubscribe = subscribeToReadingActivities(uid, setActivities);
-    return unsubscribe;
-  }, [uid]);
+    if (!user?.uid) return;
+    getFollowingUids(user.uid)
+      .then((uids) => {
+        setFollowingUids(uids);
+        if (uids.length === 0) return null;
+        return getFriendsFeed(uids, null);
+      })
+      .then((page) => {
+        if (!page) return;
+        setItems(page.items);
+        setLastDoc(page.lastDoc);
+      })
+      .catch(() => {
+        // Network or permission error — feed stays empty
+      });
+  }, [user?.uid]);
+
+  const handleLoadMore = useCallback(() => {
+    if (isLoadingMore || !lastDoc || followingUids.length === 0) return;
+    setIsLoadingMore(true);
+    getFriendsFeed(followingUids, lastDoc)
+      .then((page) => {
+        setItems((prev) => [...prev, ...page.items]);
+        setLastDoc(page.lastDoc);
+      })
+      .catch(() => {
+        // Network error — user can retry by scrolling again
+      })
+      .finally(() => {
+        setIsLoadingMore(false);
+      });
+  }, [isLoadingMore, lastDoc, followingUids]);
 
   return (
     <ScreenContainer bottomInset={tabBarInset}>
-      {activities.length > 0 ? (
+      {items.length > 0 ? (
         <FlatList
-          data={activities}
+          testID="friends-feed-list"
+          data={items}
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.list}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={isLoadingMore ? <ActivityIndicator style={styles.loader} /> : null}
           renderItem={({ item }) => (
             <View style={styles.card}>
-              <Text style={styles.cardLabel}>
-                {t('feed.finishedReading')}
-              </Text>
+              <Text style={styles.cardUser}>{item.displayLabel ?? 'Someone'}</Text>
+              <Text style={styles.cardLabel}>{t('feed.finishedReading')}</Text>
               <Text style={styles.cardTitle}>{item.title}</Text>
             </View>
           )}
@@ -95,6 +130,7 @@ const styles = StyleSheet.create({
     fontWeight: yomoyoTypography.buttonWeight,
   },
   list: { padding: 16 },
+  loader: { marginVertical: 16 },
   card: {
     backgroundColor: yomoyoColors.surface,
     borderRadius: 12,
@@ -105,6 +141,12 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.06,
     shadowRadius: 4,
     elevation: 2,
+  },
+  cardUser: {
+    fontSize: yomoyoTypography.screenBodySize,
+    fontWeight: yomoyoTypography.buttonWeight,
+    color: yomoyoColors.text,
+    marginBottom: 2,
   },
   cardLabel: {
     fontSize: 12,


### PR DESCRIPTION
Show finished-reading activities from followed users in chronological order.
- Add follows collection model (getFollowingUids)
- Add paginated getFriendsFeed query (userId in [...], finishedAt desc, limit 20)
- Denormalize displayLabel/displayAvatar into readingActivities at write time
- Update markAsFinished to accept a Presenter for feed display identity
- Replace own-activity feed with friends feed and infinite scroll in FeedScreen
- Handle network errors in both initial load and load-more paths
- Update Firestore rules: readingActivities readable by any auth user; follows collection added
- displayLabel is presentation-oriented (replaceable with animal persona later)

Required Firestore composite index: userId ASC, finishedAt DESC on readingActivities

Closes #10