### PR TITLE
feat: restore add-book entry point on Shelf screen

### DIFF
--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -37,6 +37,7 @@ const en = {
   shelf: {
     finished: 'Finished',
     emptyFinished: 'No finished books yet',
+    addBook: 'Record a finished book',
     markAsFinished: 'Mark as Finished',
   },
   settings: {

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -37,6 +37,7 @@ const ja = {
   shelf: {
     finished: '読了',
     emptyFinished: '読了した本はまだありません',
+    addBook: '読み終えた本を記録する',
     markAsFinished: '読了にする',
   },
   settings: {

--- a/src/screens/ShelfScreen.test.tsx
+++ b/src/screens/ShelfScreen.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
 import ShelfScreen from './ShelfScreen';
+
+const mockNavigate = jest.fn();
+const mockSetOptions = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
@@ -36,6 +43,8 @@ describe('ShelfScreen', () => {
   beforeEach(() => {
     mockSubscribe.mockClear();
     mockSubscribe.mockReturnValue(jest.fn());
+    mockNavigate.mockClear();
+    mockSetOptions.mockClear();
   });
 
   it('does not render the Currently Reading section', () => {
@@ -115,5 +124,32 @@ describe('ShelfScreen', () => {
     });
     render(<ShelfScreen />);
     expect(screen.queryByText('shelf.markAsFinished')).toBeNull();
+  });
+
+  it('shows an add-book CTA button in the empty state', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.addBook')).toBeTruthy();
+  });
+
+  it('navigates to BookSearch when the empty-state CTA is pressed', () => {
+    render(<ShelfScreen />);
+    fireEvent.press(screen.getByText('shelf.addBook'));
+    expect(mockNavigate).toHaveBeenCalledWith('BookSearch');
+  });
+
+  it('hides the empty-state CTA when finished activities exist', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([finishedActivity]);
+      return jest.fn();
+    });
+    render(<ShelfScreen />);
+    expect(screen.queryByText('shelf.addBook')).toBeNull();
+  });
+
+  it('registers a headerRight button via navigation.setOptions', () => {
+    render(<ShelfScreen />);
+    expect(mockSetOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ headerRight: expect.any(Function) })
+    );
   });
 });

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, ScrollView, Image, StyleSheet } from 'react-native';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
+import { View, Text, ScrollView, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
@@ -7,9 +9,13 @@ import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { useAuth } from '@/hooks/useAuth';
 import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
+import type { RootStackParamList } from '@/navigation/types';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function ShelfScreen() {
   const { t } = useTranslation();
+  const navigation = useNavigation<NavigationProp>();
   const tabBarInset = useGlassTabBarInset();
   const { user } = useAuth();
   const [activities, setActivities] = useState<ReadingActivity[]>([]);
@@ -21,12 +27,36 @@ export default function ShelfScreen() {
     return unsubscribe;
   }, [user?.uid]);
 
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() => navigation.navigate('BookSearch')}
+          accessibilityRole="button"
+          accessibilityLabel={t('shelf.addBook')}
+          style={styles.headerButton}
+        >
+          <Text style={styles.headerButtonText}>+</Text>
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, t]);
+
   return (
     <ScreenContainer bottomInset={tabBarInset}>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <Text style={styles.sectionHeader}>{t('shelf.finished')}</Text>
         {activities.length === 0 ? (
-          <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
+          <>
+            <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
+            <TouchableOpacity
+              style={styles.addButton}
+              onPress={() => navigation.navigate('BookSearch')}
+              accessibilityRole="button"
+            >
+              <Text style={styles.addButtonText}>{t('shelf.addBook')}</Text>
+            </TouchableOpacity>
+          </>
         ) : (
           activities.map((item) => (
             <View key={item.id} style={styles.card}>
@@ -109,5 +139,26 @@ const styles = StyleSheet.create({
   date: {
     fontSize: 13,
     color: yomoyoColors.muted,
+  },
+  addButton: {
+    marginTop: 16,
+    backgroundColor: yomoyoColors.primary,
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    alignSelf: 'flex-start',
+  },
+  addButtonText: {
+    color: yomoyoColors.surface,
+    fontSize: yomoyoTypography.screenBodySize,
+    fontWeight: yomoyoTypography.buttonWeight,
+  },
+  headerButton: {
+    paddingHorizontal: 8,
+  },
+  headerButtonText: {
+    fontSize: 24,
+    color: yomoyoColors.primary,
+    lineHeight: 28,
   },
 });


### PR DESCRIPTION
Add a CTA button in the empty state and a persistent header-right + button, both navigating to BookSearch so users can record a finished book.