### PR TITLE
feat: send push notifications when a reading activity is finished

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,8 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { sendExpoPush } from './expoPush';
 import { resolveRecipients } from './recipients';
 
+export { onReadingActivityFinished } from './onReadingActivityFinished';
+
 initializeApp();
 
 const REGION = 'asia-northeast1';

--- a/functions/src/onReadingActivityFinished.test.ts
+++ b/functions/src/onReadingActivityFinished.test.ts
@@ -1,0 +1,151 @@
+import {
+  validateActivityForNotification,
+  buildNotificationPayload,
+  excludeActor,
+} from './onReadingActivityFinished';
+
+describe('validateActivityForNotification', () => {
+  it('rejects null input', () => {
+    const result = validateActivityForNotification(null);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    const result = validateActivityForNotification('not-a-doc');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects when status is not "finished"', () => {
+    const result = validateActivityForNotification({
+      status: 'reading',
+      userId: 'A',
+      displayLabel: 'Foxy',
+      title: 'Norwegian Wood',
+    });
+    expect(result).toEqual({ ok: false, reason: 'status-not-finished' });
+  });
+
+  it('rejects when userId is missing', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      displayLabel: 'Foxy',
+      title: 'Norwegian Wood',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-userId' });
+  });
+
+  it('rejects when userId is empty string', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: '',
+      displayLabel: 'Foxy',
+      title: 'Norwegian Wood',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-userId' });
+  });
+
+  it('rejects when displayLabel is missing', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: 'A',
+      title: 'Norwegian Wood',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-displayLabel' });
+  });
+
+  it('rejects when displayLabel is empty string', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: 'A',
+      displayLabel: '',
+      title: 'Norwegian Wood',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-displayLabel' });
+  });
+
+  it('rejects when title is missing', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: 'A',
+      displayLabel: 'Foxy',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-title' });
+  });
+
+  it('rejects when title is empty string', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: 'A',
+      displayLabel: 'Foxy',
+      title: '',
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-title' });
+  });
+
+  it('accepts a valid finished activity and returns the extracted fields', () => {
+    const result = validateActivityForNotification({
+      status: 'finished',
+      userId: 'A',
+      displayLabel: '眠たいキツネ',
+      title: 'ノルウェイの森',
+      bookId: 'b1',
+      authors: ['村上春樹'],
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        userId: 'A',
+        displayLabel: '眠たいキツネ',
+        title: 'ノルウェイの森',
+      },
+    });
+  });
+});
+
+describe('buildNotificationPayload', () => {
+  it('builds the expected one-line Japanese body', () => {
+    const payload = buildNotificationPayload('眠たいキツネ', 'ノルウェイの森');
+    expect(payload).toEqual({
+      title: 'Yomoyo',
+      body: '眠たいキツネが「ノルウェイの森」を読み終えました。',
+    });
+  });
+
+  it('preserves arbitrary characters in label and title', () => {
+    const payload = buildNotificationPayload('A & B', 'Title-with-dashes');
+    expect(payload.title).toBe('Yomoyo');
+    expect(payload.body).toBe('A & Bが「Title-with-dashes」を読み終えました。');
+  });
+});
+
+describe('excludeActor', () => {
+  it('returns the input unchanged when the actor is not in the list', () => {
+    const recipients = [
+      { uid: 'A', token: 't1' },
+      { uid: 'B', token: 't2' },
+    ];
+    expect(excludeActor(recipients, 'X')).toEqual(recipients);
+  });
+
+  it('removes a single recipient entry that matches the actor', () => {
+    const recipients = [
+      { uid: 'A', token: 't1' },
+      { uid: 'B', token: 't2' },
+    ];
+    expect(excludeActor(recipients, 'A')).toEqual([{ uid: 'B', token: 't2' }]);
+  });
+
+  it('removes multiple actor entries (multi-device)', () => {
+    const recipients = [
+      { uid: 'A', token: 't1' },
+      { uid: 'A', token: 't2' },
+      { uid: 'B', token: 't3' },
+    ];
+    expect(excludeActor(recipients, 'A')).toEqual([{ uid: 'B', token: 't3' }]);
+  });
+
+  it('returns an empty array when only the actor was in the list', () => {
+    const recipients = [{ uid: 'A', token: 't1' }];
+    expect(excludeActor(recipients, 'A')).toEqual([]);
+  });
+});

--- a/functions/src/onReadingActivityFinished.ts
+++ b/functions/src/onReadingActivityFinished.ts
@@ -1,0 +1,130 @@
+import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions/v2';
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+
+import { sendExpoPush } from './expoPush';
+import { resolveRecipients } from './recipients';
+
+const REGION = 'asia-northeast1';
+const PUSH_TITLE = 'Yomoyo';
+
+export interface ValidatedActivity {
+  userId: string;
+  displayLabel: string;
+  title: string;
+}
+
+export type ValidationResult =
+  | { ok: true; data: ValidatedActivity }
+  | { ok: false; reason: string };
+
+export function validateActivityForNotification(
+  raw: unknown,
+): ValidationResult {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, reason: 'no-data' };
+  }
+  const data = raw as Record<string, unknown>;
+  if (data.status !== 'finished') {
+    return { ok: false, reason: 'status-not-finished' };
+  }
+  const userId = data.userId;
+  if (typeof userId !== 'string' || userId.length === 0) {
+    return { ok: false, reason: 'missing-userId' };
+  }
+  const displayLabel = data.displayLabel;
+  if (typeof displayLabel !== 'string' || displayLabel.length === 0) {
+    return { ok: false, reason: 'missing-displayLabel' };
+  }
+  const title = data.title;
+  if (typeof title !== 'string' || title.length === 0) {
+    return { ok: false, reason: 'missing-title' };
+  }
+  return { ok: true, data: { userId, displayLabel, title } };
+}
+
+export function buildNotificationPayload(
+  displayLabel: string,
+  bookTitle: string,
+): { title: string; body: string } {
+  return {
+    title: PUSH_TITLE,
+    body: `${displayLabel}が「${bookTitle}」を読み終えました。`,
+  };
+}
+
+export function excludeActor<T extends { uid: string }>(
+  recipients: readonly T[],
+  actorUid: string,
+): T[] {
+  return recipients.filter((r) => r.uid !== actorUid);
+}
+
+export const onReadingActivityFinished = onDocumentCreated(
+  {
+    document: 'readingActivities/{activityId}',
+    region: REGION,
+  },
+  async (event) => {
+    const activityId = event.params.activityId;
+    const snap = event.data;
+    if (!snap) {
+      logger.warn('onReadingActivityFinished: no snapshot', { activityId });
+      return;
+    }
+
+    const validation = validateActivityForNotification(snap.data());
+    if (!validation.ok) {
+      logger.info('onReadingActivityFinished: skipped', {
+        activityId,
+        reason: validation.reason,
+      });
+      return;
+    }
+    const { userId: sourceUid, displayLabel, title } = validation.data;
+
+    const db = getFirestore();
+    const activityRef = db.collection('readingActivities').doc(activityId);
+
+    const claimed = await db.runTransaction(async (txn) => {
+      const cur = await txn.get(activityRef);
+      if (!cur.exists) return false;
+      if (cur.get('notifiedAt')) return false;
+      txn.update(activityRef, { notifiedAt: FieldValue.serverTimestamp() });
+      return true;
+    });
+    if (!claimed) {
+      logger.info('onReadingActivityFinished: already notified', {
+        activityId,
+        sourceUid,
+      });
+      return;
+    }
+
+    const allRecipients = await resolveRecipients(db, sourceUid);
+    const recipients = excludeActor(allRecipients, sourceUid);
+
+    if (recipients.length === 0) {
+      logger.info('onReadingActivityFinished: no recipients', {
+        activityId,
+        sourceUid,
+      });
+      return;
+    }
+
+    const payload = buildNotificationPayload(displayLabel, title);
+    const results = await Promise.allSettled(
+      recipients.map((r) => sendExpoPush(r.token, payload)),
+    );
+    const sent = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.length - sent;
+
+    logger.info('onReadingActivityFinished: dispatched', {
+      activityId,
+      sourceUid,
+      recipientCount: recipients.length,
+      sent,
+      failed,
+    });
+  },
+);

--- a/functions/src/onReadingActivityFinished.ts
+++ b/functions/src/onReadingActivityFinished.ts
@@ -83,48 +83,56 @@ export const onReadingActivityFinished = onDocumentCreated(
     }
     const { userId: sourceUid, displayLabel, title } = validation.data;
 
-    const db = getFirestore();
-    const activityRef = db.collection('readingActivities').doc(activityId);
+    try {
+      const db = getFirestore();
+      const activityRef = db.collection('readingActivities').doc(activityId);
 
-    const claimed = await db.runTransaction(async (txn) => {
-      const cur = await txn.get(activityRef);
-      if (!cur.exists) return false;
-      if (cur.get('notifiedAt')) return false;
-      txn.update(activityRef, { notifiedAt: FieldValue.serverTimestamp() });
-      return true;
-    });
-    if (!claimed) {
-      logger.info('onReadingActivityFinished: already notified', {
+      const claimed = await db.runTransaction(async (txn) => {
+        const cur = await txn.get(activityRef);
+        if (!cur.exists) return false;
+        if (cur.get('notifiedAt')) return false;
+        txn.update(activityRef, { notifiedAt: FieldValue.serverTimestamp() });
+        return true;
+      });
+      if (!claimed) {
+        logger.info('onReadingActivityFinished: already notified', {
+          activityId,
+          sourceUid,
+        });
+        return;
+      }
+
+      const allRecipients = await resolveRecipients(db, sourceUid);
+      const recipients = excludeActor(allRecipients, sourceUid);
+
+      if (recipients.length === 0) {
+        logger.info('onReadingActivityFinished: no recipients', {
+          activityId,
+          sourceUid,
+        });
+        return;
+      }
+
+      const payload = buildNotificationPayload(displayLabel, title);
+      const results = await Promise.allSettled(
+        recipients.map((r) => sendExpoPush(r.token, payload)),
+      );
+      const sent = results.filter((r) => r.status === 'fulfilled').length;
+      const failed = results.length - sent;
+
+      logger.info('onReadingActivityFinished: dispatched', {
         activityId,
         sourceUid,
+        recipientCount: recipients.length,
+        sent,
+        failed,
       });
-      return;
-    }
-
-    const allRecipients = await resolveRecipients(db, sourceUid);
-    const recipients = excludeActor(allRecipients, sourceUid);
-
-    if (recipients.length === 0) {
-      logger.info('onReadingActivityFinished: no recipients', {
+    } catch (err) {
+      logger.error('onReadingActivityFinished: failed', {
         activityId,
         sourceUid,
+        error: err instanceof Error ? err.message : String(err),
       });
-      return;
     }
-
-    const payload = buildNotificationPayload(displayLabel, title);
-    const results = await Promise.allSettled(
-      recipients.map((r) => sendExpoPush(r.token, payload)),
-    );
-    const sent = results.filter((r) => r.status === 'fulfilled').length;
-    const failed = results.length - sent;
-
-    logger.info('onReadingActivityFinished: dispatched', {
-      activityId,
-      sourceUid,
-      recipientCount: recipients.length,
-      sent,
-      failed,
-    });
   },
 );

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
   "jest": {
     "preset": "jest-expo",
     "watchman": false,
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/functions/"
+    ],
     "moduleNameMapper": {
       "^firebase/firestore$": "<rootDir>/__mocks__/firebase/firestore.js",
       "^firebase/app$": "<rootDir>/__mocks__/firebase/app.js",


### PR DESCRIPTION
## Summary
- Adds an `onDocumentCreated` trigger on `readingActivities/{activityId}` that, for each newly-finished reading, resolves the actor's followers via `resolveRecipients` and fans out a single-line Japanese push to every enabled token.
- Idempotency is enforced inside a Firestore transaction: the trigger claims the dispatch by setting `notifiedAt` on the same activity doc; any retry / duplicate event delivery finds it already set and bails without re-sending.
- The actor is also defensively excluded from their own recipient list.
- Per-recipient sends use `Promise.allSettled` so a single failed device does not block delivery to the rest.
- Server logs include only safe operational data (`activityId`, `sourceUid`, recipient counts) — never tokens.
- Adds `chore: stop running functions/ tests under root jest` so each suite has a single runner; functions/ tests now run only via `cd funcons && npm test`.
- Connects to issues #45 (`sendExpoPush`) and #46 (`resolveRecipients`).

## Manual setup (one-time, if not already in place)
- Cloud Run public access (`invoker: 'public'` already in code) — survives redeploys.
- Compute Engine default SA needs `roles/datastore.user`.
- Firebase project on Blaze plan.
- First Firestore-trigger deploy may need an Eventarc IAM role grant; the deploy error message names the exact role if so.

## Test plan
- [x] Functions build clean (`npm run build`)
- [x] Functions tests 34/34 pass (3 expoPush + 15 recipients + 16 onReadingActivityFinished)
- [x] Root tests 360/360 pass under the new jest config
- [ ] On-device end-to-end: Device A finishes a book → Device B (a follower, app backgrounded) receives `…が「…」を読み終えました。` push; Device A receives nothing
- [ ] Re-mark same book → no second push (idempotency)

## Intentionally deferred
- No retry / dead-letter queue, no notification history, no batching, no receipt polling, no analytdy-length truncation, no localization (issue #48 picks that up).
- Trigger-orchestration unit tests (M3 from the code review) — captured as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)