### PR TITLE
【保留】feat: switch book search to Rakuten Books API

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -24,7 +24,7 @@ cp .env.example .env
 
 - `IOS_BUNDLE_IDENTIFIER` / `ANDROID_PACKAGE_NAME` — 開発者自身のXコードで登録した署名を利用する (例： `com.yourname.yomoyo`) 
 - `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` — Google Cloud Console → Credentials → OAuth 2.0 → Web application
-- `EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY` — Google Cloud Console → Credentials → API key
+- `EXPO_PUBLIC_RAKUTEN_APPLICATION_ID` — Rakuten Developers → アプリID/デベロッパーID登録 → アプリID
 - `EXPO_PUBLIC_FIREBASE_*` — Firebase Console → Project settings → Your apps → `GoogleService-Info.plist`
 
 ### 3. FirebaseのConfigファイルを設置

--- a/src/lib/books/searchBooks.test.ts
+++ b/src/lib/books/searchBooks.test.ts
@@ -1,5 +1,8 @@
 import { searchBooks } from './searchBooks';
 
+const APP_ID_ENV = 'EXPO_PUBLIC_RAKUTEN_APPLICATION_ID';
+const TEST_APP_ID = 'test-app-id';
+
 function makeFetchOk(body: object): Response {
   return {
     ok: true,
@@ -12,131 +15,232 @@ function makeFetchError(status: number): Response {
   return { ok: false, status } as unknown as Response;
 }
 
-describe('searchBooks', () => {
+describe('searchBooks (Rakuten Books)', () => {
+  let originalAppId: string | undefined;
+
+  beforeEach(() => {
+    originalAppId = process.env[APP_ID_ENV];
+    process.env[APP_ID_ENV] = TEST_APP_ID;
+  });
+
   afterEach(() => {
+    if (originalAppId === undefined) delete process.env[APP_ID_ENV];
+    else process.env[APP_ID_ENV] = originalAppId;
     jest.restoreAllMocks();
   });
 
-  it('returns empty array when API response has no items', async () => {
+  it('returns empty array when API response has no Items', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
     const result = await searchBooks('test');
     expect(result).toEqual([]);
   });
 
-  it('maps a full volume to a Book', async () => {
+  it('maps a full Rakuten item to a Book with isbn-based, rk-prefixed id', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
       makeFetchOk({
-        items: [
+        Items: [
           {
-            id: 'abc',
-            volumeInfo: {
-              title: 'The Great Gatsby',
-              authors: ['F. Scott Fitzgerald'],
-              imageLinks: { thumbnail: 'http://books.google.com/thumbnail.jpg' },
+            Item: {
+              title: '吾輩は猫である',
+              author: '夏目漱石',
+              isbn: '9784101010014',
+              mediumImageUrl: 'https://thumbnail.image.rakuten.co.jp/foo.jpg',
             },
           },
         ],
       }),
     );
-    const result = await searchBooks('gatsby');
+    const result = await searchBooks('猫');
     expect(result).toEqual([
       {
-        id: 'abc',
-        title: 'The Great Gatsby',
-        authors: ['F. Scott Fitzgerald'],
-        thumbnail: 'https://books.google.com/thumbnail.jpg',
+        id: 'rk:9784101010014',
+        title: '吾輩は猫である',
+        authors: ['夏目漱石'],
+        thumbnail: 'https://thumbnail.image.rakuten.co.jp/foo.jpg',
       },
     ]);
   });
 
-  it('defaults authors to empty array when missing', async () => {
+  it('falls back to itemCode when isbn is empty', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
       makeFetchOk({
-        items: [{ id: 'xyz', volumeInfo: { title: 'Unknown Book' } }],
+        Items: [
+          {
+            Item: {
+              title: 'Some Book',
+              author: 'Author',
+              isbn: '',
+              itemCode: 'books:12345678',
+              mediumImageUrl: '',
+            },
+          },
+        ],
       }),
     );
-    const [book] = await searchBooks('unknown');
+    const [book] = await searchBooks('test');
+    expect(book.id).toBe('rk:books:12345678');
+  });
+
+  it('skips items that have neither isbn nor itemCode', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [
+          { Item: { title: 'No ID', author: 'A', isbn: '' } },
+          { Item: { title: 'With ISBN', author: 'B', isbn: '9784000000000' } },
+        ],
+      }),
+    );
+    const result = await searchBooks('test');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('rk:9784000000000');
+  });
+
+  it('splits author string on Japanese full-width slash', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [
+          {
+            Item: {
+              title: 'Book',
+              author: '著者A／著者B',
+              isbn: '9784000000001',
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('test');
+    expect(book.authors).toEqual(['著者A', '著者B']);
+  });
+
+  it('splits author string on comma and ideographic comma', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [
+          {
+            Item: {
+              title: 'Book',
+              author: 'Author A, Author B、Author C',
+              isbn: '9784000000002',
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('test');
+    expect(book.authors).toEqual(['Author A', 'Author B', 'Author C']);
+  });
+
+  it('does not split author on ASCII slash', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [
+          {
+            Item: {
+              title: 'Book',
+              author: 'Smith/Jones',
+              isbn: '9784000000010',
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('test');
+    expect(book.authors).toEqual(['Smith/Jones']);
+  });
+
+  it('returns empty authors when author field is missing', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [{ Item: { title: 'Book', isbn: '9784000000003' } }],
+      }),
+    );
+    const [book] = await searchBooks('test');
     expect(book.authors).toEqual([]);
   });
 
-  it('sets thumbnail to null when imageLinks is missing', async () => {
+  it('returns empty authors when author field is an empty string', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
       makeFetchOk({
-        items: [{ id: 'xyz', volumeInfo: { title: 'No Cover', authors: ['Author'] } }],
+        Items: [{ Item: { title: 'Book', author: '', isbn: '9784000000007' } }],
       }),
     );
-    const [book] = await searchBooks('no cover');
+    const [book] = await searchBooks('test');
+    expect(book.authors).toEqual([]);
+  });
+
+  it('sets thumbnail to null when no image URL is present', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [{ Item: { title: 'Book', author: 'A', isbn: '9784000000004' } }],
+      }),
+    );
+    const [book] = await searchBooks('test');
     expect(book.thumbnail).toBeNull();
   });
 
   it('converts http thumbnail URL to https', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(
       makeFetchOk({
-        items: [
+        Items: [
           {
-            id: 'xyz',
-            volumeInfo: {
+            Item: {
               title: 'Book',
-              authors: ['Author'],
-              imageLinks: { thumbnail: 'http://books.google.com/img.jpg' },
+              author: 'A',
+              isbn: '9784000000005',
+              mediumImageUrl: 'http://thumbnail.image.rakuten.co.jp/foo.jpg',
             },
           },
         ],
       }),
     );
-    const [book] = await searchBooks('book');
-    expect(book.thumbnail).toBe('https://books.google.com/img.jpg');
+    const [book] = await searchBooks('test');
+    expect(book.thumbnail).toBe('https://thumbnail.image.rakuten.co.jp/foo.jpg');
   });
 
-  it('throws when the API responds with an error status', async () => {
+  it('sets thumbnail to null when image URL is malformed', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      makeFetchOk({
+        Items: [
+          {
+            Item: {
+              title: 'Book',
+              author: 'A',
+              isbn: '9784000000006',
+              mediumImageUrl: 'not a url',
+            },
+          },
+        ],
+      }),
+    );
+    const [book] = await searchBooks('test');
+    expect(book.thumbnail).toBeNull();
+  });
+
+  it('throws "Books API error: <status>" on HTTP error', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchError(500));
     await expect(searchBooks('test')).rejects.toThrow('Books API error: 500');
   });
 
-  it('sets thumbnail to null when the URL is malformed', async () => {
-    jest.spyOn(global, 'fetch').mockResolvedValue(
-      makeFetchOk({
-        items: [
-          {
-            id: 'xyz',
-            volumeInfo: {
-              title: 'Book',
-              authors: ['Author'],
-              imageLinks: { thumbnail: 'not a url' },
-            },
-          },
-        ],
-      }),
-    );
-    const [book] = await searchBooks('book');
-    expect(book.thumbnail).toBeNull();
+  it('preserves the 429 error format used by the UI rate-limit mapping', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchError(429));
+    await expect(searchBooks('test')).rejects.toThrow('Books API error: 429');
   });
 
-  it('includes the query in the fetch URL', async () => {
+  it('throws when EXPO_PUBLIC_RAKUTEN_APPLICATION_ID is not set', async () => {
+    delete process.env[APP_ID_ENV];
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
-    await searchBooks('hello world');
-    const url = spy.mock.calls[0][0] as string;
-    expect(url).toContain('q=');
-    expect(decodeURIComponent(url.replace(/\+/g, ' '))).toContain('hello world');
+    await expect(searchBooks('test')).rejects.toThrow();
+    expect(spy).not.toHaveBeenCalled();
   });
 
-  it('appends key param when EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY is set', async () => {
-    const original = process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY;
-    process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY = 'test-api-key-123';
+  it('calls the Rakuten BooksBook endpoint with applicationId and keyword', async () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
-    await searchBooks('gatsby');
+    await searchBooks('夏目漱石');
     const url = spy.mock.calls[0][0] as string;
-    expect(url).toContain('key=test-api-key-123');
-    process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY = original;
-  });
-
-  it('omits the key param when EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY is not set', async () => {
-    const original = process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY;
-    delete process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY;
-    const spy = jest.spyOn(global, 'fetch').mockResolvedValue(makeFetchOk({}));
-    await searchBooks('gatsby');
-    const url = spy.mock.calls[0][0] as string;
-    expect(url).not.toContain('key=');
-    process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY = original;
+    expect(url).toContain('app.rakuten.co.jp/services/api/BooksBook/Search/20170404');
+    expect(url).toContain(`applicationId=${TEST_APP_ID}`);
+    expect(url).toContain('keyword=');
+    expect(decodeURIComponent(url)).toContain('夏目漱石');
   });
 });

--- a/src/lib/books/searchBooks.ts
+++ b/src/lib/books/searchBooks.ts
@@ -1,4 +1,7 @@
-const BASE_URL = 'https://www.googleapis.com/books/v1/volumes';
+const BASE_URL = 'https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404';
+const ID_PREFIX = 'rk:';
+const APP_ID_ENV = 'EXPO_PUBLIC_RAKUTEN_APPLICATION_ID';
+const AUTHOR_SEPARATOR = /[,、／]+/;
 
 export type Book = {
   id: string;
@@ -7,20 +10,22 @@ export type Book = {
   thumbnail: string | null;
 };
 
-type GoogleBooksVolume = {
-  id: string;
-  volumeInfo: {
-    title: string;
-    authors?: string[];
-    imageLinks?: { thumbnail?: string };
-  };
+type RakutenBookItem = {
+  title?: string;
+  author?: string;
+  isbn?: string;
+  itemCode?: string;
+  smallImageUrl?: string;
+  mediumImageUrl?: string;
+  largeImageUrl?: string;
 };
 
-type GoogleBooksResponse = {
-  items?: GoogleBooksVolume[];
+type RakutenBooksResponse = {
+  Items?: { Item: RakutenBookItem }[];
 };
 
 function toSafeHttpsUrl(raw: string): string | null {
+  if (!raw) return null;
   const url = raw.replace('http://', 'https://');
   try {
     const parsed = new URL(url);
@@ -30,27 +35,51 @@ function toSafeHttpsUrl(raw: string): string | null {
   }
 }
 
-function mapVolume(item: GoogleBooksVolume): Book {
-  const raw = item.volumeInfo.imageLinks?.thumbnail ?? null;
+function pickThumbnail(item: RakutenBookItem): string | null {
+  const raw = item.mediumImageUrl || item.largeImageUrl || item.smallImageUrl;
+  return raw ? toSafeHttpsUrl(raw) : null;
+}
+
+function splitAuthors(author: string | undefined): string[] {
+  if (!author) return [];
+  return author
+    .split(AUTHOR_SEPARATOR)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function pickId(item: RakutenBookItem): string | null {
+  const isbn = item.isbn?.trim();
+  if (isbn) return `${ID_PREFIX}${isbn}`;
+  const itemCode = item.itemCode?.trim();
+  if (itemCode) return `${ID_PREFIX}${itemCode}`;
+  return null;
+}
+
+function mapItem(wrapper: { Item: RakutenBookItem }): Book | null {
+  const item = wrapper.Item;
+  const id = pickId(item);
+  if (!id || !item.title) return null;
   return {
-    id: item.id,
-    title: item.volumeInfo.title,
-    authors: item.volumeInfo.authors ?? [],
-    thumbnail: raw ? toSafeHttpsUrl(raw) : null,
+    id,
+    title: item.title,
+    authors: splitAuthors(item.author),
+    thumbnail: pickThumbnail(item),
   };
 }
 
 export async function searchBooks(query: string): Promise<Book[]> {
-  const params = new URLSearchParams({ q: query });
-  const apiKey = process.env.EXPO_PUBLIC_GOOGLE_BOOKS_API_KEY;
-  if (__DEV__) {
-    console.log('[Books] API key:', apiKey ? `${apiKey.slice(0, 4)}...` : 'NOT SET');
+  const applicationId = process.env[APP_ID_ENV];
+  if (!applicationId) {
+    throw new Error(`Books API config error: ${APP_ID_ENV} is not set`);
   }
-  if (apiKey) params.append('key', apiKey);
 
+  const params = new URLSearchParams({ applicationId, keyword: query });
   const response = await fetch(`${BASE_URL}?${params}`);
   if (!response.ok) throw new Error(`Books API error: ${response.status}`);
 
-  const data: GoogleBooksResponse = await response.json();
-  return (data.items ?? []).map(mapVolume);
+  const data: RakutenBooksResponse = await response.json();
+  return (data.Items ?? [])
+    .map(mapItem)
+    .filter((book): book is Book => book !== null);
 }


### PR DESCRIPTION
- replace Google Books with Rakuten BooksBook/Search/20170404 as the primary keyword search provider for better Japanese coverage
- keep the public Book contract and Books API error: <status> throw format unchanged so screens, navigation, and persistence are untouched
- namespace book ids as rk:<isbn|itemCode>; require EXPO_PUBLIC_RAKUTEN_APPLICATION_ID and fail explicitly when unset