### PR TITLE
feat: add friend search by exact handle ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 dist/
 ios/
 android/
+coverage/
 .env
 .env.local
 *.log

--- a/__mocks__/firebase/firestore.js
+++ b/__mocks__/firebase/firestore.js
@@ -16,6 +16,17 @@ const mockGetDoc = jest.fn(() =>
   Promise.resolve({ exists: () => false, data: () => undefined }),
 );
 const mockDeleteDoc = jest.fn(() => Promise.resolve());
+const mockRunTransaction = jest.fn(async (_db, callback) => {
+  const tx = {
+    get: jest.fn(() =>
+      Promise.resolve({ exists: () => false, data: () => undefined }),
+    ),
+    set: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  return callback(tx);
+});
 
 module.exports = {
   getFirestore: mockGetFirestore,
@@ -33,4 +44,5 @@ module.exports = {
   onSnapshot: mockOnSnapshot,
   serverTimestamp: mockServerTimestamp,
   getDoc: mockGetDoc,
+  runTransaction: mockRunTransaction,
 };

--- a/firestore.rules
+++ b/firestore.rules
@@ -30,5 +30,22 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
     }
+
+    // Handle reservations: maps a human-readable handle to its owner uid.
+    // Authed users can `get` a single handle by exact ID for friend lookup,
+    // but `list` is denied so the collection cannot be enumerated as a
+    // public directory of user IDs.
+    // Only the claimed owner can create the reservation, and the handle
+    // must satisfy the canonical format (defense-in-depth against a
+    // misbehaving client).
+    // Updates and deletes are disallowed in v1: handles are immutable.
+    match /handles/{handle} {
+      allow get: if request.auth != null;
+      allow list: if false;
+      allow create: if request.auth != null
+        && request.auth.uid == request.resource.data.uid
+        && handle.matches('^[a-z0-9_]{4,20}$');
+      allow update, delete: if false;
+    }
   }
 }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -16,7 +16,11 @@ const en = {
   },
   addFriend: {
     heading: 'Add a friend',
-    comingSoonBody: 'Friend search by ID is coming soon.',
+    placeholder: "Enter your friend's ID",
+    search: 'Search',
+    notFound: 'No user with that ID.',
+    selfMatch: "That's your own ID.",
+    viewProfile: 'View profile',
     close: 'Close',
   },
   bookSearch: {
@@ -38,9 +42,9 @@ const en = {
   },
   settings: {
     languageTitle: 'Language',
-    profileLinkTitle: 'Profile Link',
-    copyLink: 'Copy Link',
-    linkCopied: 'Copied!',
+    yourIdTitle: 'Your ID',
+    shareId: 'Share my ID',
+    idShared: 'Shared!',
   },
   userProfile: {
     follow: 'Receive updates',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -16,7 +16,11 @@ const ja = {
   },
   addFriend: {
     heading: '友達を追加',
-    comingSoonBody: 'IDでの友達検索は近日公開予定です。',
+    placeholder: '友達のIDを入力',
+    search: '検索',
+    notFound: 'そのIDのユーザーは見つかりませんでした。',
+    selfMatch: 'これはあなた自身のIDです。',
+    viewProfile: 'プロフィールを見る',
     close: '閉じる',
   },
   bookSearch: {
@@ -38,9 +42,9 @@ const ja = {
   },
   settings: {
     languageTitle: '言語',
-    profileLinkTitle: 'プロフィールリンク',
-    copyLink: 'リンクをコピー',
-    linkCopied: 'コピーしました',
+    yourIdTitle: 'あなたのID',
+    shareId: 'IDを共有',
+    idShared: '共有しました',
   },
   userProfile: {
     follow: 'おたよりを受け取る',

--- a/src/lib/users/handles.test.ts
+++ b/src/lib/users/handles.test.ts
@@ -1,0 +1,385 @@
+import {
+  generateRandomHandle,
+  isValidHandle,
+  normalizeHandle,
+  ensureHandle,
+  getUserHandle,
+  findUidByHandle,
+  HANDLE_REGEX,
+} from './handles';
+import { doc, getDoc, runTransaction, serverTimestamp } from 'firebase/firestore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('HANDLE_REGEX', () => {
+  it('accepts 4 to 20 lowercase ASCII alphanumeric and underscore', () => {
+    expect(HANDLE_REGEX.test('abcd')).toBe(true);
+    expect(HANDLE_REGEX.test('with_under')).toBe(true);
+    expect(HANDLE_REGEX.test('a'.repeat(20))).toBe(true);
+  });
+
+  it('rejects too short', () => {
+    expect(HANDLE_REGEX.test('abc')).toBe(false);
+    expect(HANDLE_REGEX.test('')).toBe(false);
+  });
+
+  it('rejects too long', () => {
+    expect(HANDLE_REGEX.test('a'.repeat(21))).toBe(false);
+  });
+
+  it('rejects uppercase', () => {
+    expect(HANDLE_REGEX.test('Abcd')).toBe(false);
+  });
+
+  it('rejects whitespace and special characters', () => {
+    expect(HANDLE_REGEX.test('ab-cd')).toBe(false);
+    expect(HANDLE_REGEX.test('ab.cd')).toBe(false);
+    expect(HANDLE_REGEX.test('ab cd')).toBe(false);
+    expect(HANDLE_REGEX.test('あいうえ')).toBe(false);
+  });
+});
+
+describe('isValidHandle', () => {
+  it('returns true for a valid handle', () => {
+    expect(isValidHandle('quietfox42')).toBe(true);
+  });
+
+  it('returns false for an invalid handle', () => {
+    expect(isValidHandle('Q!')).toBe(false);
+  });
+});
+
+describe('normalizeHandle', () => {
+  it('lowercases input', () => {
+    expect(normalizeHandle('AbcDef')).toBe('abcdef');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeHandle('  abc  ')).toBe('abc');
+  });
+
+  it('does not strip invalid characters', () => {
+    expect(normalizeHandle('Ab-cd')).toBe('ab-cd');
+  });
+});
+
+describe('generateRandomHandle', () => {
+  it('always returns a string matching HANDLE_REGEX', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(HANDLE_REGEX.test(generateRandomHandle())).toBe(true);
+    }
+  });
+
+  it('returns different handles across multiple calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) seen.add(generateRandomHandle());
+    expect(seen.size).toBeGreaterThan(40);
+  });
+});
+
+describe('ensureHandle', () => {
+  function mockExistingHandle(handle: string) {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle }),
+    } as any);
+  }
+
+  function mockNoHandleYet() {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ animalKey: 'fox' }),
+    } as any);
+  }
+
+  type TxBehavior = {
+    userInTx?: { exists: boolean; data?: Record<string, unknown> };
+    handleInTx?: { exists: boolean };
+  };
+
+  function queueTransaction(behavior: TxBehavior = {}): jest.Mock {
+    const set = jest.fn();
+    jest.mocked(runTransaction).mockImplementationOnce(async (_db, cb) => {
+      const tx = {
+        get: jest
+          .fn()
+          .mockResolvedValueOnce({
+            exists: () => behavior.userInTx?.exists ?? true,
+            data: () => behavior.userInTx?.data ?? {},
+          })
+          .mockResolvedValueOnce({
+            exists: () => behavior.handleInTx?.exists ?? false,
+            data: () => undefined,
+          }),
+        set,
+        update: jest.fn(),
+        delete: jest.fn(),
+      };
+      return (cb as (tx: any) => any)(tx);
+    });
+    return set;
+  }
+
+  it('returns the existing handle when users/{uid}.handle is already set', async () => {
+    mockExistingHandle('foo123');
+
+    const result = await ensureHandle('user1');
+
+    expect(result).toBe('foo123');
+    expect(jest.mocked(runTransaction)).not.toHaveBeenCalled();
+  });
+
+  it('reads users/{uid} to look up the existing handle', async () => {
+    mockExistingHandle('foo123');
+
+    await ensureHandle('user1');
+
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'users', 'user1');
+    expect(jest.mocked(getDoc)).toHaveBeenCalled();
+  });
+
+  it('regenerates when the existing handle is malformed', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle: 'BAD!HANDLE' }),
+    } as any);
+    const set = queueTransaction();
+
+    const result = await ensureHandle('user1');
+
+    expect(HANDLE_REGEX.test(result)).toBe(true);
+    expect(set).toHaveBeenCalled();
+  });
+
+  it('reserves a fresh handle when none is assigned', async () => {
+    mockNoHandleYet();
+    const set = queueTransaction();
+
+    const result = await ensureHandle('user1');
+
+    expect(HANDLE_REGEX.test(result)).toBe(true);
+    expect(set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ uid: 'user1', createdAt: expect.anything() }),
+    );
+    expect(set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ handle: result }),
+      { merge: true },
+    );
+    expect(jest.mocked(serverTimestamp)).toHaveBeenCalled();
+  });
+
+  it('addresses the new handle document at handles/{candidate}', async () => {
+    mockNoHandleYet();
+    queueTransaction();
+
+    const result = await ensureHandle('user1');
+
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'handles', result);
+  });
+
+  it('retries with a fresh candidate when the first candidate is taken', async () => {
+    mockNoHandleYet();
+    queueTransaction({ handleInTx: { exists: true } });
+    queueTransaction();
+
+    const result = await ensureHandle('user1');
+
+    expect(HANDLE_REGEX.test(result)).toBe(true);
+    expect(jest.mocked(runTransaction)).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the concurrent handle if another caller assigned one during the transaction', async () => {
+    mockNoHandleYet();
+    queueTransaction({ userInTx: { exists: true, data: { handle: 'concurrent1' } } });
+
+    const result = await ensureHandle('user1');
+
+    expect(result).toBe('concurrent1');
+  });
+
+  it('throws after exhausting all retry attempts', async () => {
+    mockNoHandleYet();
+    jest.mocked(runTransaction).mockImplementation(async (_db, cb) => {
+      const tx = {
+        get: jest
+          .fn()
+          .mockResolvedValueOnce({ exists: () => true, data: () => ({}) })
+          .mockResolvedValueOnce({ exists: () => true, data: () => ({}) }),
+        set: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      };
+      return (cb as (tx: any) => any)(tx);
+    });
+
+    await expect(ensureHandle('user1')).rejects.toThrow();
+  });
+
+  it('propagates non-conflict errors from the transaction', async () => {
+    mockNoHandleYet();
+    jest.mocked(runTransaction).mockRejectedValueOnce(new Error('network down'));
+
+    await expect(ensureHandle('user1')).rejects.toThrow('network down');
+  });
+});
+
+describe('getUserHandle', () => {
+  it('returns the handle when users/{uid}.handle is a valid string', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle: 'quietfox' }),
+    } as any);
+
+    const result = await getUserHandle('user1');
+
+    expect(result).toBe('quietfox');
+  });
+
+  it('reads from users/{uid}', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle: 'quietfox' }),
+    } as any);
+
+    await getUserHandle('user1');
+
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'users', 'user1');
+  });
+
+  it('returns null when the user document does not exist', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => false,
+      data: () => undefined,
+    } as any);
+
+    const result = await getUserHandle('user1');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the handle field is missing', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ animalKey: 'fox' }),
+    } as any);
+
+    const result = await getUserHandle('user1');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the handle field is malformed', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle: 'BAD!HANDLE' }),
+    } as any);
+
+    const result = await getUserHandle('user1');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the handle field is not a string', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ handle: 42 }),
+    } as any);
+
+    const result = await getUserHandle('user1');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('findUidByHandle', () => {
+  it('returns the uid when handles/{handle} exists', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ uid: 'user42' }),
+    } as any);
+
+    const result = await findUidByHandle('quietfox');
+
+    expect(result).toBe('user42');
+  });
+
+  it('reads from handles/{normalizedHandle}', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ uid: 'user42' }),
+    } as any);
+
+    await findUidByHandle('  QuietFox  ');
+
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(expect.anything(), 'handles', 'quietfox');
+  });
+
+  it('returns null when handles/{handle} does not exist', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => false,
+      data: () => undefined,
+    } as any);
+
+    const result = await findUidByHandle('quietfox');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null without hitting Firestore when input is empty', async () => {
+    const result = await findUidByHandle('');
+
+    expect(result).toBeNull();
+    expect(jest.mocked(getDoc)).not.toHaveBeenCalled();
+  });
+
+  it('returns null without hitting Firestore when input is too short', async () => {
+    const result = await findUidByHandle('abc');
+
+    expect(result).toBeNull();
+    expect(jest.mocked(getDoc)).not.toHaveBeenCalled();
+  });
+
+  it('returns null without hitting Firestore when input has invalid characters', async () => {
+    const result = await findUidByHandle('foo-bar');
+
+    expect(result).toBeNull();
+    expect(jest.mocked(getDoc)).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the uid field is missing', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({}),
+    } as any);
+
+    const result = await findUidByHandle('quietfox');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the uid field is not a string', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ uid: 42 }),
+    } as any);
+
+    const result = await findUidByHandle('quietfox');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the uid field is an empty string', async () => {
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ uid: '' }),
+    } as any);
+
+    const result = await findUidByHandle('quietfox');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/users/handles.ts
+++ b/src/lib/users/handles.ts
@@ -1,0 +1,90 @@
+import {
+  getFirestore,
+  doc,
+  getDoc,
+  runTransaction,
+  serverTimestamp,
+  type Firestore,
+  type DocumentReference,
+} from 'firebase/firestore';
+
+export const HANDLE_REGEX = /^[a-z0-9_]{4,20}$/;
+
+const HANDLE_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+const HANDLE_LENGTH = 8;
+const MAX_ENSURE_ATTEMPTS = 5;
+
+export function isValidHandle(handle: string): boolean {
+  return HANDLE_REGEX.test(handle);
+}
+
+export function normalizeHandle(input: string): string {
+  return input.trim().toLowerCase();
+}
+
+export function generateRandomHandle(): string {
+  let out = '';
+  for (let i = 0; i < HANDLE_LENGTH; i++) {
+    out += HANDLE_ALPHABET[Math.floor(Math.random() * HANDLE_ALPHABET.length)];
+  }
+  return out;
+}
+
+export async function findUidByHandle(input: string): Promise<string | null> {
+  const normalized = normalizeHandle(input);
+  if (!isValidHandle(normalized)) return null;
+  const db = getFirestore();
+  const snap = await getDoc(doc(db, 'handles', normalized));
+  if (!snap.exists()) return null;
+  const uid = snap.data()?.uid;
+  if (typeof uid !== 'string' || uid.length === 0) return null;
+  return uid;
+}
+
+export async function getUserHandle(uid: string): Promise<string | null> {
+  const db = getFirestore();
+  const snap = await getDoc(doc(db, 'users', uid));
+  if (!snap.exists()) return null;
+  const handle = snap.data()?.handle;
+  if (typeof handle !== 'string' || !isValidHandle(handle)) return null;
+  return handle;
+}
+
+export async function ensureHandle(uid: string): Promise<string> {
+  const db = getFirestore();
+  const userRef = doc(db, 'users', uid);
+  const snap = await getDoc(userRef);
+  const existing = snap.exists() ? (snap.data()?.handle as string | undefined) : undefined;
+  if (existing && isValidHandle(existing)) return existing;
+
+  for (let attempt = 0; attempt < MAX_ENSURE_ATTEMPTS; attempt++) {
+    const candidate = generateRandomHandle();
+    const handleRef = doc(db, 'handles', candidate);
+    const reserved = await tryReserveHandle(db, userRef, handleRef, candidate, uid);
+    if (reserved) return reserved;
+  }
+  throw new Error('failed to reserve handle');
+}
+
+async function tryReserveHandle(
+  db: Firestore,
+  userRef: DocumentReference,
+  handleRef: DocumentReference,
+  candidate: string,
+  uid: string,
+): Promise<string | null> {
+  return runTransaction(db, async (tx) => {
+    const userSnap = await tx.get(userRef);
+    const concurrent = userSnap.exists()
+      ? (userSnap.data()?.handle as string | undefined)
+      : undefined;
+    if (concurrent && isValidHandle(concurrent)) return concurrent;
+
+    const handleSnap = await tx.get(handleRef);
+    if (handleSnap.exists()) return null;
+
+    tx.set(handleRef, { uid, createdAt: serverTimestamp() });
+    tx.set(userRef, { handle: candidate }, { merge: true });
+    return candidate;
+  });
+}

--- a/src/navigation/RootNavigator.test.tsx
+++ b/src/navigation/RootNavigator.test.tsx
@@ -35,8 +35,13 @@ jest.mock('@/lib/notifications/registerPushToken', () => ({
   registerPushTokenIfPermitted: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('@/lib/users/handles', () => ({
+  ensureHandle: jest.fn().mockResolvedValue('quietfox'),
+}));
+
 import { checkFirstLaunch } from '@/lib/onboarding';
 import { registerPushTokenIfPermitted } from '@/lib/notifications/registerPushToken';
+import { ensureHandle } from '@/lib/users/handles';
 
 function renderWithNav() {
   return render(
@@ -124,5 +129,32 @@ describe('RootNavigator', () => {
     renderWithNav();
     await screen.findByText('OnboardingNavigator');
     expect(registerPushTokenIfPermitted).not.toHaveBeenCalled();
+  });
+
+  it('ensures a handle on startup when user is authenticated and onboarding is done', async () => {
+    jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      user: { uid: 'abc123' } as any,
+      loading: false,
+    });
+    renderWithNav();
+    await waitFor(() => expect(ensureHandle).toHaveBeenCalledWith('abc123'));
+  });
+
+  it('does not ensure a handle on startup when user is signed out', async () => {
+    jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({ user: null, loading: false });
+    renderWithNav();
+    await screen.findByText('LoginScreen');
+    expect(ensureHandle).not.toHaveBeenCalled();
+  });
+
+  it('does not ensure a handle while onboarding is still active', async () => {
+    jest.mocked(checkFirstLaunch).mockResolvedValue(true);
+    jest.spyOn(useAuthModule, 'useAuth').mockReturnValue({
+      user: { uid: 'abc123' } as any,
+      loading: false,
+    });
+    renderWithNav();
+    await screen.findByText('OnboardingNavigator');
+    expect(ensureHandle).not.toHaveBeenCalled();
   });
 });

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -6,6 +6,7 @@ import LoginScreen from '@/screens/LoginScreen';
 import { useAuth } from '@/hooks/useAuth';
 import { checkFirstLaunch } from '@/lib/onboarding';
 import { registerPushTokenIfPermitted } from '@/lib/notifications/registerPushToken';
+import { ensureHandle } from '@/lib/users/handles';
 
 type AuthStackParamList = {
   App: undefined;
@@ -27,6 +28,7 @@ export default function RootNavigator() {
   useEffect(() => {
     if (user && onboardingDone) {
       registerPushTokenIfPermitted(user.uid);
+      ensureHandle(user.uid).catch(() => {});
     }
   }, [user, onboardingDone]);
 

--- a/src/screens/AddFriendScreen.test.tsx
+++ b/src/screens/AddFriendScreen.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import AddFriendScreen from './AddFriendScreen';
+import { findUidByHandle } from '@/lib/users/handles';
+import { getAvatarIdentity } from '@/lib/users/avatarIdentity';
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -16,19 +19,40 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
 }));
 
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'me-uid' }, loading: false }),
+}));
+
+jest.mock('@/lib/users/handles', () => ({
+  findUidByHandle: jest.fn(),
+}));
+
+jest.mock('@/lib/users/avatarIdentity', () => ({
+  getAvatarIdentity: jest.fn(),
+  ANIMAL_ASSETS: { fox: 1, bear: 2 },
+}));
+
+const mockedFindUid = findUidByHandle as jest.Mock;
+const mockedGetAvatar = getAvatarIdentity as jest.Mock;
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('AddFriendScreen', () => {
+describe('AddFriendScreen — initial render', () => {
   it('renders the heading', () => {
     render(<AddFriendScreen />);
     expect(screen.getByText('addFriend.heading')).toBeTruthy();
   });
 
-  it('renders the coming-soon body', () => {
+  it('renders the handle input', () => {
     render(<AddFriendScreen />);
-    expect(screen.getByText('addFriend.comingSoonBody')).toBeTruthy();
+    expect(screen.getByPlaceholderText('addFriend.placeholder')).toBeTruthy();
+  });
+
+  it('renders the search button', () => {
+    render(<AddFriendScreen />);
+    expect(screen.getByText('addFriend.search')).toBeTruthy();
   });
 
   it('renders a close button', () => {
@@ -36,9 +60,152 @@ describe('AddFriendScreen', () => {
     expect(screen.getByTestId('add-friend-close-button')).toBeTruthy();
   });
 
-  it('calls navigation.goBack when the close button is pressed', () => {
+  it('calls navigation.goBack when close is pressed', () => {
     render(<AddFriendScreen />);
     fireEvent.press(screen.getByTestId('add-friend-close-button'));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show any result message before searching', () => {
+    render(<AddFriendScreen />);
+    expect(screen.queryByText('addFriend.notFound')).toBeNull();
+    expect(screen.queryByText('addFriend.selfMatch')).toBeNull();
+  });
+});
+
+describe('AddFriendScreen — search behavior', () => {
+  it('shows the not-found message when no match exists', async () => {
+    mockedFindUid.mockResolvedValueOnce(null);
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'unknown1',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('addFriend.notFound')).toBeTruthy();
+    });
+  });
+
+  it('shows the self-match message when the handle resolves to the current user', async () => {
+    mockedFindUid.mockResolvedValueOnce('me-uid');
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'myself1',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('addFriend.selfMatch')).toBeTruthy();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate or fetch the avatar on a self-match', async () => {
+    mockedFindUid.mockResolvedValueOnce('me-uid');
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'myself1',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('addFriend.selfMatch')).toBeTruthy();
+    });
+    expect(mockedGetAvatar).not.toHaveBeenCalled();
+  });
+
+  it('shows the matched user display label when a different user matches', async () => {
+    mockedFindUid.mockResolvedValueOnce('friend-uid');
+    mockedGetAvatar.mockResolvedValueOnce({
+      animalKey: 'fox',
+      adjective: 'Quiet',
+      displayLabel: 'Quiet Fox',
+      finalizedAt: null,
+    });
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'quietfox',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('Quiet Fox')).toBeTruthy();
+    });
+  });
+
+  it('renders a "View profile" button on a successful match', async () => {
+    mockedFindUid.mockResolvedValueOnce('friend-uid');
+    mockedGetAvatar.mockResolvedValueOnce({
+      animalKey: 'fox',
+      adjective: 'Quiet',
+      displayLabel: 'Quiet Fox',
+      finalizedAt: null,
+    });
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'quietfox',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    expect(await screen.findByText('addFriend.viewProfile')).toBeTruthy();
+  });
+
+  it('navigates to UserProfile with the matched uid when View profile is pressed', async () => {
+    mockedFindUid.mockResolvedValueOnce('friend-uid');
+    mockedGetAvatar.mockResolvedValueOnce({
+      animalKey: 'fox',
+      adjective: 'Quiet',
+      displayLabel: 'Quiet Fox',
+      finalizedAt: null,
+    });
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'quietfox',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    fireEvent.press(await screen.findByText('addFriend.viewProfile'));
+    expect(mockNavigate).toHaveBeenCalledWith('UserProfile', { uid: 'friend-uid' });
+  });
+
+  it('shows not-found when the matched user has no avatar identity', async () => {
+    mockedFindUid.mockResolvedValueOnce('friend-uid');
+    mockedGetAvatar.mockResolvedValueOnce(null);
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'quietfox',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('addFriend.notFound')).toBeTruthy();
+    });
+  });
+
+  it('shows not-found when the lookup throws', async () => {
+    mockedFindUid.mockRejectedValueOnce(new Error('network error'));
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      'quietfox',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(screen.getByText('addFriend.notFound')).toBeTruthy();
+    });
+  });
+
+  it('passes the raw input to findUidByHandle (normalization happens inside)', async () => {
+    mockedFindUid.mockResolvedValueOnce(null);
+    render(<AddFriendScreen />);
+    fireEvent.changeText(
+      screen.getByPlaceholderText('addFriend.placeholder'),
+      '  QuietFox  ',
+    );
+    fireEvent.press(screen.getByText('addFriend.search'));
+    await waitFor(() => {
+      expect(mockedFindUid).toHaveBeenCalledWith('  QuietFox  ');
+    });
   });
 });

--- a/src/screens/AddFriendScreen.tsx
+++ b/src/screens/AddFriendScreen.tsx
@@ -1,23 +1,123 @@
-import React from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Pressable,
+  Image,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
+import { useAuth } from '@/hooks/useAuth';
+import { findUidByHandle } from '@/lib/users/handles';
+import { getAvatarIdentity, ANIMAL_ASSETS } from '@/lib/users/avatarIdentity';
+import type { AnimalKey } from '@/lib/users/avatarIdentity';
 import type { RootStackParamList } from '@/navigation/types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
+type SearchState =
+  | { kind: 'idle' }
+  | { kind: 'searching' }
+  | { kind: 'notFound' }
+  | { kind: 'self' }
+  | { kind: 'match'; uid: string; displayLabel: string; animalKey: AnimalKey };
+
 export default function AddFriendScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
+  const { user } = useAuth();
+  const [input, setInput] = useState('');
+  const [state, setState] = useState<SearchState>({ kind: 'idle' });
+
+  const handleSearch = async () => {
+    setState({ kind: 'searching' });
+    try {
+      const matchUid = await findUidByHandle(input);
+      if (!matchUid) {
+        setState({ kind: 'notFound' });
+        return;
+      }
+      if (matchUid === user?.uid) {
+        setState({ kind: 'self' });
+        return;
+      }
+      const profile = await getAvatarIdentity(matchUid);
+      if (!profile) {
+        setState({ kind: 'notFound' });
+        return;
+      }
+      setState({
+        kind: 'match',
+        uid: matchUid,
+        displayLabel: profile.displayLabel,
+        animalKey: profile.animalKey,
+      });
+    } catch {
+      setState({ kind: 'notFound' });
+    }
+  };
+
+  const handleViewProfile = () => {
+    if (state.kind !== 'match') return;
+    navigation.navigate('UserProfile', { uid: state.uid });
+  };
 
   return (
     <ScreenContainer>
       <View style={styles.content}>
         <Text style={styles.heading}>{t('addFriend.heading')}</Text>
-        <Text style={styles.body}>{t('addFriend.comingSoonBody')}</Text>
+
+        <View style={styles.searchRow}>
+          <TextInput
+            style={styles.input}
+            placeholder={t('addFriend.placeholder')}
+            value={input}
+            onChangeText={setInput}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            onSubmitEditing={handleSearch}
+          />
+          <TouchableOpacity
+            style={[styles.searchButton, state.kind === 'searching' && styles.searchButtonDisabled]}
+            onPress={handleSearch}
+            disabled={state.kind === 'searching'}
+            accessibilityRole="button"
+          >
+            <Text style={styles.searchButtonText}>{t('addFriend.search')}</Text>
+          </TouchableOpacity>
+        </View>
+
+        {state.kind === 'searching' && <ActivityIndicator style={styles.loading} />}
+
+        {state.kind === 'notFound' && (
+          <Text style={styles.message}>{t('addFriend.notFound')}</Text>
+        )}
+
+        {state.kind === 'self' && (
+          <Text style={styles.message}>{t('addFriend.selfMatch')}</Text>
+        )}
+
+        {state.kind === 'match' && (
+          <View style={styles.matchCard} testID="match-card">
+            <Image source={ANIMAL_ASSETS[state.animalKey]} style={styles.avatar} />
+            <Text style={styles.matchLabel}>{state.displayLabel}</Text>
+            <TouchableOpacity
+              style={styles.viewProfileButton}
+              onPress={handleViewProfile}
+              accessibilityRole="button"
+            >
+              <Text style={styles.viewProfileText}>{t('addFriend.viewProfile')}</Text>
+            </TouchableOpacity>
+          </View>
+        )}
 
         <Pressable
           testID="add-friend-close-button"
@@ -35,27 +135,95 @@ export default function AddFriendScreen() {
 const styles = StyleSheet.create({
   content: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
     paddingHorizontal: 16,
+    paddingTop: 24,
   },
   heading: {
     fontSize: yomoyoTypography.screenTitleSize,
     fontWeight: yomoyoTypography.titleWeight,
     color: yomoyoColors.text,
-    marginBottom: 12,
     textAlign: 'center',
+    marginBottom: 24,
   },
-  body: {
+  searchRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 24,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: yomoyoColors.border,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
     fontSize: yomoyoTypography.screenBodySize,
-    lineHeight: yomoyoTypography.screenBodyLineHeight,
-    color: yomoyoColors.secondaryText,
+    color: yomoyoColors.text,
+  },
+  searchButton: {
+    backgroundColor: yomoyoColors.primary,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+  },
+  searchButtonDisabled: {
+    opacity: 0.5,
+  },
+  searchButtonText: {
+    color: yomoyoColors.surface,
+    fontSize: yomoyoTypography.screenBodySize,
+    fontWeight: yomoyoTypography.buttonWeight,
+  },
+  loading: {
+    marginTop: 16,
+  },
+  message: {
+    marginTop: 16,
     textAlign: 'center',
-    marginBottom: 32,
+    fontSize: yomoyoTypography.screenBodySize,
+    color: yomoyoColors.muted,
+  },
+  matchCard: {
+    marginTop: 16,
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: yomoyoColors.surface,
+    borderRadius: 12,
+    shadowColor: yomoyoColors.text,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    marginBottom: 12,
+  },
+  matchLabel: {
+    fontSize: yomoyoTypography.titleSize,
+    fontWeight: yomoyoTypography.titleWeight,
+    color: yomoyoColors.text,
+    marginBottom: 16,
+  },
+  viewProfileButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderWidth: 1,
+    borderColor: yomoyoColors.primary,
+    borderRadius: 20,
+  },
+  viewProfileText: {
+    fontSize: yomoyoTypography.screenBodySize,
+    fontWeight: yomoyoTypography.buttonWeight,
+    color: yomoyoColors.primary,
   },
   closeButton: {
+    marginTop: 'auto',
+    alignSelf: 'center',
     paddingHorizontal: 24,
-    paddingVertical: 10,
+    paddingVertical: 14,
   },
   closeText: {
     fontSize: yomoyoTypography.screenBodySize,

--- a/src/screens/OnboardingAvatarScreen.test.tsx
+++ b/src/screens/OnboardingAvatarScreen.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react-nativ
 import OnboardingAvatarScreen from './OnboardingAvatarScreen';
 import { useNavigation } from '@react-navigation/native';
 import { generateRandomIdentity, saveAvatarIdentity } from '@/lib/users/avatarIdentity';
+import { ensureHandle } from '@/lib/users/handles';
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -25,6 +26,10 @@ jest.mock('@/lib/users/avatarIdentity', () => ({
   })),
   saveAvatarIdentity: jest.fn(() => Promise.resolve()),
   ANIMAL_ASSETS: { fox: 1, bear: 2 },
+}));
+
+jest.mock('@/lib/users/handles', () => ({
+  ensureHandle: jest.fn(() => Promise.resolve('quietfox')),
 }));
 
 describe('OnboardingAvatarScreen', () => {
@@ -120,5 +125,22 @@ describe('OnboardingAvatarScreen', () => {
     fireEvent.press(screen.getByText('onboarding.avatarContinue'));
     fireEvent.press(screen.getByText('onboarding.avatarContinue'));
     expect(jest.mocked(saveAvatarIdentity)).toHaveBeenCalledTimes(1);
+  });
+
+  it('reserves a handle for the user when continue is pressed', async () => {
+    render(<OnboardingAvatarScreen />);
+    fireEvent.press(screen.getByText('onboarding.avatarContinue'));
+    await waitFor(() => {
+      expect(ensureHandle).toHaveBeenCalledWith('user1');
+    });
+  });
+
+  it('still navigates to OnboardingNotification when ensureHandle fails', async () => {
+    jest.mocked(ensureHandle).mockRejectedValueOnce(new Error('reservation failed'));
+    render(<OnboardingAvatarScreen />);
+    fireEvent.press(screen.getByText('onboarding.avatarContinue'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('OnboardingNotification');
+    });
   });
 });

--- a/src/screens/OnboardingAvatarScreen.tsx
+++ b/src/screens/OnboardingAvatarScreen.tsx
@@ -10,6 +10,7 @@ import {
   ANIMAL_ASSETS,
 } from '@/lib/users/avatarIdentity';
 import type { DraftIdentity } from '@/lib/users/avatarIdentity';
+import { ensureHandle } from '@/lib/users/handles';
 import type { OnboardingStackParamList } from '@/navigation/types';
 import { yomoyoColors, yomoyoTypography, yomoyoSpacing } from '@/constants/yomoyoTheme';
 
@@ -34,6 +35,7 @@ export default function OnboardingAvatarScreen() {
     // user is always set here (avatar screen follows sign-in), guard is for type safety
     if (user) {
       saveAvatarIdentity(user.uid, identity).catch(() => {});
+      ensureHandle(user.uid).catch(() => {});
     }
     navigation.navigate('OnboardingNotification');
   };

--- a/src/screens/SettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react-native';
 import SettingsScreen from './SettingsScreen';
 import { setLanguage } from '@/lib/i18n';
 import { registerPushTokenIfPermitted } from '@/lib/notifications/registerPushToken';
+import { getUserHandle } from '@/lib/users/handles';
 import { Share } from 'react-native';
 
 jest.mock('@/lib/i18n', () => ({
@@ -13,7 +14,12 @@ jest.mock('@/lib/notifications/registerPushToken', () => ({
   registerPushTokenIfPermitted: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('@/lib/users/handles', () => ({
+  getUserHandle: jest.fn().mockResolvedValue('quietfox'),
+}));
+
 const mockedRegisterPushToken = registerPushTokenIfPermitted as jest.Mock;
+const mockedGetUserHandle = getUserHandle as jest.Mock;
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
@@ -90,39 +96,82 @@ describe('SettingsScreen', () => {
   });
 });
 
-describe('SettingsScreen — profile link', () => {
+describe('SettingsScreen — your ID', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedGetUserHandle.mockResolvedValue('quietfox');
   });
 
-  it('renders the profile link section title', () => {
+  it('renders the your-ID section title', () => {
     render(<SettingsScreen />);
-    expect(screen.getByText('settings.profileLinkTitle')).toBeTruthy();
+    expect(screen.getByText('settings.yourIdTitle')).toBeTruthy();
   });
 
-  it('renders the copy link button', () => {
+  it('fetches the current user handle on mount', async () => {
     render(<SettingsScreen />);
-    expect(screen.getByText('settings.copyLink')).toBeTruthy();
+    await waitFor(() => expect(mockedGetUserHandle).toHaveBeenCalledWith('user1'));
   });
 
-  it('calls Share.share with the profile link when copy button is pressed', async () => {
+  it('displays the loaded handle', async () => {
     render(<SettingsScreen />);
-    fireEvent.press(screen.getByText('settings.copyLink'));
+    expect(await screen.findByText('quietfox')).toBeTruthy();
+  });
+
+  it('renders a share-ID button', async () => {
+    render(<SettingsScreen />);
+    expect(await screen.findByText('settings.shareId')).toBeTruthy();
+  });
+
+  it('calls Share.share with the handle as the message', async () => {
+    render(<SettingsScreen />);
+    fireEvent.press(await screen.findByText('settings.shareId'));
     await waitFor(() => {
-      expect(Share.share).toHaveBeenCalledWith({ message: 'yomoyo://user/user1' });
+      expect(Share.share).toHaveBeenCalledWith({ message: 'quietfox' });
     });
   });
 
-  it('shows linkCopied confirmation text after pressing copy', async () => {
+  it('shows the shared confirmation after pressing share', async () => {
     render(<SettingsScreen />);
-    fireEvent.press(screen.getByText('settings.copyLink'));
+    fireEvent.press(await screen.findByText('settings.shareId'));
     await waitFor(() => {
-      expect(screen.getByText('settings.linkCopied')).toBeTruthy();
+      expect(screen.getByText('settings.idShared')).toBeTruthy();
     });
   });
 
-  it('does not show linkCopied text before copy button is pressed', () => {
+  it('does not show the shared confirmation before share is pressed', () => {
     render(<SettingsScreen />);
-    expect(screen.queryByText('settings.linkCopied')).toBeNull();
+    expect(screen.queryByText('settings.idShared')).toBeNull();
+  });
+
+  it('does not crash when getUserHandle returns null', async () => {
+    mockedGetUserHandle.mockResolvedValueOnce(null);
+    render(<SettingsScreen />);
+    await waitFor(() => expect(mockedGetUserHandle).toHaveBeenCalled());
+    expect(screen.queryByText('quietfox')).toBeNull();
+  });
+
+  it('disables the share button while the handle is unavailable', async () => {
+    mockedGetUserHandle.mockResolvedValueOnce(null);
+    render(<SettingsScreen />);
+    await waitFor(() => expect(mockedGetUserHandle).toHaveBeenCalled());
+    fireEvent.press(screen.getByText('settings.shareId'));
+    expect(Share.share).not.toHaveBeenCalled();
+  });
+
+  it('hides the shared confirmation after a short delay', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<SettingsScreen />);
+      fireEvent.press(await screen.findByText('settings.shareId'));
+      await waitFor(() => {
+        expect(screen.getByText('settings.idShared')).toBeTruthy();
+      });
+      act(() => {
+        jest.advanceTimersByTime(2500);
+      });
+      expect(screen.queryByText('settings.idShared')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,27 +1,44 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Share } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { setLanguage } from '@/lib/i18n';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import GlassCard from '@/components/ui/GlassCard';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
-import { yomoyoColors, yomoyoGlass } from '@/constants/yomoyoTheme';
+import { yomoyoColors, yomoyoGlass, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { useAuth } from '@/hooks/useAuth';
 import { registerPushTokenIfPermitted } from '@/lib/notifications/registerPushToken';
+import { getUserHandle } from '@/lib/users/handles';
 
 type Language = 'ja' | 'en';
+
+const SHARED_CONFIRMATION_MS = 2000;
 
 export default function SettingsScreen() {
   const { t, i18n } = useTranslation();
   const currentLanguage = (i18n.language.split('-')[0] ?? 'en') as Language;
   const tabBarInset = useGlassTabBarInset();
   const { user } = useAuth();
-  const [copied, setCopied] = useState(false);
+  const [handle, setHandle] = useState<string | null>(null);
+  const [shared, setShared] = useState(false);
 
-  const handleCopyLink = () => {
+  useEffect(() => {
     if (!user) return;
-    Share.share({ message: `yomoyo://user/${user.uid}` })
-      .then(() => setCopied(true))
+    getUserHandle(user.uid)
+      .then(setHandle)
+      .catch(() => setHandle(null));
+  }, [user?.uid]);
+
+  useEffect(() => {
+    if (!shared) return;
+    const id = setTimeout(() => setShared(false), SHARED_CONFIRMATION_MS);
+    return () => clearTimeout(id);
+  }, [shared]);
+
+  const handleShare = () => {
+    if (!handle) return;
+    Share.share({ message: handle })
+      .then(() => setShared(true))
       .catch(() => {});
   };
 
@@ -35,18 +52,24 @@ export default function SettingsScreen() {
   return (
     <ScreenContainer bottomInset={tabBarInset}>
       <View style={styles.content}>
-        <Text style={styles.sectionLabel}>{t('settings.profileLinkTitle')}</Text>
+        <Text style={styles.sectionLabel}>{t('settings.yourIdTitle')}</Text>
         <GlassCard>
-          <TouchableOpacity
-            style={styles.linkButton}
-            onPress={handleCopyLink}
-            accessibilityRole="button"
-          >
-            <Text style={styles.linkButtonText}>{t('settings.copyLink')}</Text>
-          </TouchableOpacity>
-          {copied && (
-            <Text style={styles.linkCopiedText}>{t('settings.linkCopied')}</Text>
-          )}
+          <View style={styles.idBlock}>
+            {handle ? (
+              <Text style={styles.handleText}>{handle}</Text>
+            ) : (
+              <Text style={styles.handlePlaceholder}>—</Text>
+            )}
+            <TouchableOpacity
+              style={[styles.shareButton, !handle && styles.shareButtonDisabled]}
+              onPress={handleShare}
+              disabled={!handle}
+              accessibilityRole="button"
+            >
+              <Text style={styles.shareButtonText}>{t('settings.shareId')}</Text>
+            </TouchableOpacity>
+            {shared && <Text style={styles.sharedText}>{t('settings.idShared')}</Text>}
+          </View>
         </GlassCard>
 
         <Text style={[styles.sectionLabel, styles.sectionLabelSpaced]}>{t('settings.languageTitle')}</Text>
@@ -90,20 +113,38 @@ const styles = StyleSheet.create({
   sectionLabelSpaced: {
     marginTop: 24,
   },
-  linkButton: {
-    paddingVertical: 14,
+  idBlock: {
+    paddingVertical: 12,
     alignItems: 'center',
   },
-  linkButtonText: {
+  handleText: {
+    fontSize: yomoyoTypography.titleSize,
+    fontWeight: yomoyoTypography.titleWeight,
+    color: yomoyoColors.text,
+    marginBottom: 12,
+  },
+  handlePlaceholder: {
+    fontSize: yomoyoTypography.titleSize,
+    color: yomoyoColors.muted,
+    marginBottom: 12,
+  },
+  shareButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  shareButtonDisabled: {
+    opacity: 0.5,
+  },
+  shareButtonText: {
     fontSize: 16,
     fontWeight: '500',
     color: yomoyoColors.primary,
   },
-  linkCopiedText: {
+  sharedText: {
     fontSize: 13,
     color: yomoyoColors.muted,
     textAlign: 'center',
-    paddingBottom: 8,
+    paddingTop: 4,
   },
   row: {
     flexDirection: 'row',


### PR DESCRIPTION
Implements issue #55. Yomoyo gains a non-public friend-lookup flow:

- Add /handles/{handle} reservation collection. Firestore rules permit authed get only (list denied so the collection cannot be enumerated as a public directory of user IDs); create only by the claimed owner with a regex match for defense in depth; update and delete denied.
- ensureHandle reserves a handle transactionally for new users during onboarding and backfills legacy users on app start.
- SettingsScreen surfaces the current user's handle with a Share action and an auto-clearing confirmation.
- Replace AddFriendScreen stub with an exact-match search screen. A successful match shows the friend's displayLabel + avatar and routes to UserProfile, where the existing follow flow performs the actual add. Self-match short-circuits before any avatar fetch. The matched user's handle is never rendered.
- i18n: add addFriend.{placeholder,search,notFound,selfMatch, viewProfile} and settings.{yourIdTitle,shareId,idShared}; remove addFriend.comingSoonBody and the old profile-link keys.