### PR TITLE
feat: introduce AdMob foundation with test banner in Timeline

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import RootNavigator from '@/navigation/RootNavigator';
 import i18n, { loadSavedLanguage } from '@/lib/i18n';
 import { linkingConfig } from '@/navigation/linkingConfig';
+import { initAdMob } from '@/lib/ads/initAdMob';
 
 export default function App() {
   const [ready, setReady] = useState(false);
@@ -14,6 +15,10 @@ export default function App() {
       .then((lang) => (lang ? i18n.changeLanguage(lang) : undefined))
       .then(() => setReady(true))
       .catch(() => setReady(true));
+  }, []);
+
+  useEffect(() => {
+    void initAdMob();
   }, []);
 
   if (!ready) return null;

--- a/__mocks__/react-native-google-mobile-ads.js
+++ b/__mocks__/react-native-google-mobile-ads.js
@@ -1,0 +1,33 @@
+const React = require('react');
+const { View } = require('react-native');
+
+const initialize = jest.fn(() => Promise.resolve([{}]));
+const instance = {
+  initialize,
+  setRequestConfiguration: jest.fn(() => Promise.resolve()),
+};
+const mobileAds = jest.fn(() => instance);
+
+const BannerAd = ({ unitId, size }) =>
+  React.createElement(View, { testID: 'timeline-banner-ad', unitId, size });
+
+const BannerAdSize = {
+  ANCHORED_ADAPTIVE_BANNER: 'ANCHORED_ADAPTIVE_BANNER',
+  BANNER: 'BANNER',
+  LARGE_BANNER: 'LARGE_BANNER',
+  MEDIUM_RECTANGLE: 'MEDIUM_RECTANGLE',
+};
+
+const TestIds = {
+  BANNER: 'ca-app-pub-3940256099942544/6300978111',
+  INTERSTITIAL: 'ca-app-pub-3940256099942544/1033173712',
+  REWARDED: 'ca-app-pub-3940256099942544/5224354917',
+};
+
+module.exports = {
+  __esModule: true,
+  default: mobileAds,
+  BannerAd,
+  BannerAdSize,
+  TestIds,
+};

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,5 +1,14 @@
 import { ExpoConfig, ConfigContext } from 'expo/config';
 
+// Fallbacks are Google's public sample AdMob app IDs from the official AdMob
+// docs — safe to commit, used until real account IDs are wired via env vars.
+const ADMOB_IOS_APP_ID =
+  process.env.EXPO_PUBLIC_ADMOB_IOS_APP_ID ??
+  'ca-app-pub-3940256099942544~1458002511';
+const ADMOB_ANDROID_APP_ID =
+  process.env.EXPO_PUBLIC_ADMOB_ANDROID_APP_ID ??
+  'ca-app-pub-3940256099942544~3347511713';
+
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   ios: {
@@ -12,4 +21,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     package:
       process.env.ANDROID_PACKAGE_NAME ?? 'com.furugenisland.yomoyo',
   },
+  plugins: [
+    ...(config.plugins ?? []),
+    [
+      'react-native-google-mobile-ads',
+      {
+        android_app_id: ADMOB_ANDROID_APP_ID,
+        ios_app_id: ADMOB_IOS_APP_ID,
+      },
+    ],
+  ],
 });

--- a/app.config.ts
+++ b/app.config.ts
@@ -26,8 +26,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'react-native-google-mobile-ads',
       {
-        android_app_id: ADMOB_ANDROID_APP_ID,
-        ios_app_id: ADMOB_IOS_APP_ID,
+        androidAppId: ADMOB_ANDROID_APP_ID,
+        iosAppId: ADMOB_IOS_APP_ID,
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "19.1.0",
     "react-i18next": "^17.0.6",
     "react-native": "0.81.5",
+    "react-native-google-mobile-ads": "^14.7.0",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.16.0"
   },
@@ -72,7 +73,8 @@
       "@react-native-async-storage/async-storage": "<rootDir>/__mocks__/@react-native-async-storage/async-storage.js",
       "expo-notifications": "<rootDir>/__mocks__/expo-notifications.js",
       "expo-video": "<rootDir>/__mocks__/expo-video.js",
-      "expo-blur": "<rootDir>/__mocks__/expo-blur.js"
+      "expo-blur": "<rootDir>/__mocks__/expo-blur.js",
+      "react-native-google-mobile-ads": "<rootDir>/__mocks__/react-native-google-mobile-ads.js"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native-google-mobile-ads:
+        specifier: ^14.7.0
+        version: 14.11.0(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0)
       react-native-safe-area-context:
         specifier: ^5.4.0
         version: 5.7.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1137,6 +1140,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@iabtcf/core@1.5.6':
+    resolution: {integrity: sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==}
 
   '@invertase/react-native-apple-authentication@2.5.1':
     resolution: {integrity: sha512-KPKKc0wtRYpH4J0RkDfHzoKSZ+dYPEHmCXhpPdgHsT2MbK5AIkW1cYurjhAgev/kL7nOHFmWITjY1At5WhFEMQ==}
@@ -2357,6 +2363,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -4442,6 +4452,14 @@ packages:
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
 
+  react-native-google-mobile-ads@14.11.0:
+    resolution: {integrity: sha512-OWCuk4fR7eLyQT4u2A98tAdgTTFA5/QXUxQEt89LtBJUSALh/Go3wye7X+259b/lszbOOFMxojpPFIMSKeCXmQ==}
+    peerDependencies:
+      expo: '>=47.0.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
     peerDependencies:
@@ -5081,6 +5099,12 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-deep-compare-effect@1.8.1:
+    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13'
 
   use-latest-callback@0.2.6:
     resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
@@ -6790,6 +6814,8 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@iabtcf/core@1.5.6': {}
+
   '@invertase/react-native-apple-authentication@2.5.1': {}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -8272,6 +8298,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -11063,6 +11091,15 @@ snapshots:
 
   react-is@19.2.5: {}
 
+  react-native-google-mobile-ads@14.11.0(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0):
+    dependencies:
+      '@iabtcf/core': 1.5.6
+      use-deep-compare-effect: 1.8.1(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - react
+
   react-native-is-edge-to-edge@1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -11828,6 +11865,12 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-deep-compare-effect@1.8.1(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dequal: 2.0.3
+      react: 19.1.0
 
   use-latest-callback@0.2.6(react@19.1.0):
     dependencies:

--- a/src/components/ads/AdErrorBoundary.test.tsx
+++ b/src/components/ads/AdErrorBoundary.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import AdErrorBoundary from './AdErrorBoundary';
+
+const Thrower = () => {
+  throw new Error('boom');
+};
+
+describe('AdErrorBoundary', () => {
+  it('renders its children when no error is thrown', () => {
+    render(
+      <AdErrorBoundary>
+        <Text>safe child</Text>
+      </AdErrorBoundary>,
+    );
+    expect(screen.getByText('safe child')).toBeTruthy();
+  });
+
+  it('renders nothing when a descendant throws during render', () => {
+    render(
+      <AdErrorBoundary>
+        <Thrower />
+      </AdErrorBoundary>,
+    );
+    expect(screen.queryByText('safe child')).toBeNull();
+  });
+});

--- a/src/components/ads/AdErrorBoundary.tsx
+++ b/src/components/ads/AdErrorBoundary.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+type Props = { children: React.ReactNode };
+type State = { hasError: boolean };
+
+export default class AdErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(err: unknown): void {
+    const e = err as { message?: string };
+    console.error('[AdErrorBoundary] render failed —', e?.message ?? err);
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}

--- a/src/components/ads/TimelineBannerAd.test.tsx
+++ b/src/components/ads/TimelineBannerAd.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import TimelineBannerAd from './TimelineBannerAd';
+import { TestIds } from 'react-native-google-mobile-ads';
+
+describe('TimelineBannerAd', () => {
+  it('renders the AdMob BannerAd with the test unit ID by default', () => {
+    render(<TimelineBannerAd />);
+    const banner = screen.getByTestId('timeline-banner-ad');
+    expect(banner.props.unitId).toBe(TestIds.BANNER);
+  });
+
+  it('uses the adaptive banner size', () => {
+    render(<TimelineBannerAd />);
+    const banner = screen.getByTestId('timeline-banner-ad');
+    expect(banner.props.size).toBe('ANCHORED_ADAPTIVE_BANNER');
+  });
+});

--- a/src/components/ads/TimelineBannerAd.tsx
+++ b/src/components/ads/TimelineBannerAd.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { BannerAd, BannerAdSize, TestIds } from 'react-native-google-mobile-ads';
+import AdErrorBoundary from './AdErrorBoundary';
+
+const TimelineBannerAd = React.memo(function TimelineBannerAd() {
+  return (
+    <AdErrorBoundary>
+      <BannerAd unitId={TestIds.BANNER} size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER} />
+    </AdErrorBoundary>
+  );
+});
+
+export default TimelineBannerAd;

--- a/src/constants/ads.ts
+++ b/src/constants/ads.ts
@@ -1,0 +1,1 @@
+export const TIMELINE_AD_CADENCE = 6;

--- a/src/lib/ads/initAdMob.test.ts
+++ b/src/lib/ads/initAdMob.test.ts
@@ -1,0 +1,31 @@
+import mobileAds from 'react-native-google-mobile-ads';
+import { initAdMob, __resetAdMobInitForTests } from './initAdMob';
+
+const mockedMobileAds = mobileAds as unknown as jest.Mock;
+const getInitializeMock = () =>
+  (mobileAds() as unknown as { initialize: jest.Mock }).initialize;
+
+describe('initAdMob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetAdMobInitForTests();
+  });
+
+  it('initializes the Mobile Ads SDK once on first call', async () => {
+    await initAdMob();
+    expect(mockedMobileAds).toHaveBeenCalled();
+    expect(getInitializeMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-initialize on subsequent calls', async () => {
+    await initAdMob();
+    await initAdMob();
+    await initAdMob();
+    expect(getInitializeMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows initialization errors so the app can still boot', async () => {
+    getInitializeMock().mockRejectedValueOnce(new Error('boom'));
+    await expect(initAdMob()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/ads/initAdMob.ts
+++ b/src/lib/ads/initAdMob.ts
@@ -1,0 +1,21 @@
+import mobileAds from 'react-native-google-mobile-ads';
+
+let initPromise: Promise<void> | null = null;
+
+export function initAdMob(): Promise<void> {
+  if (initPromise) return initPromise;
+  const promise: Promise<void> = mobileAds()
+    .initialize()
+    .then(() => undefined)
+    .catch((err: unknown) => {
+      const e = err as { message?: string };
+      console.error('[initAdMob] init failed —', e?.message ?? err);
+      return undefined;
+    });
+  initPromise = promise;
+  return promise;
+}
+
+export function __resetAdMobInitForTests(): void {
+  initPromise = null;
+}

--- a/src/lib/ads/interleaveAds.test.ts
+++ b/src/lib/ads/interleaveAds.test.ts
@@ -1,0 +1,62 @@
+import { interleaveAds } from './interleaveAds';
+
+type Sample = { id: string };
+
+const make = (n: number): Sample[] =>
+  Array.from({ length: n }, (_, i) => ({ id: `item-${i}` }));
+
+describe('interleaveAds', () => {
+  it('returns an empty list for an empty input', () => {
+    expect(interleaveAds<Sample>([], 6)).toEqual([]);
+  });
+
+  it('returns just items when fewer than the cadence is provided', () => {
+    const items = make(5);
+    const rows = interleaveAds(items, 6);
+    expect(rows).toHaveLength(5);
+    expect(rows.every((r) => r.kind === 'item')).toBe(true);
+  });
+
+  it('does not append a trailing ad when item count equals the cadence', () => {
+    const items = make(6);
+    const rows = interleaveAds(items, 6);
+    expect(rows).toHaveLength(6);
+    expect(rows.every((r) => r.kind === 'item')).toBe(true);
+  });
+
+  it('inserts an ad after every Nth item, only when more items follow', () => {
+    const items = make(13);
+    const rows = interleaveAds(items, 6);
+
+    expect(rows[0].kind).toBe('item');
+    expect(rows[5].kind).toBe('item');
+    expect(rows[6].kind).toBe('ad');
+    expect(rows[7].kind).toBe('item');
+    expect(rows[12].kind).toBe('item');
+    expect(rows[13].kind).toBe('ad');
+    expect(rows[14].kind).toBe('item');
+    expect(rows).toHaveLength(15);
+  });
+
+  it('never places an ad at the first position', () => {
+    for (const n of [1, 6, 7, 12, 13, 50]) {
+      const rows = interleaveAds(make(n), 6);
+      if (rows.length > 0) {
+        expect(rows[0].kind).toBe('item');
+      }
+    }
+  });
+
+  it('produces stable, unique ad keys per ad position', () => {
+    const rows = interleaveAds(make(13), 6);
+    const adKeys = rows.filter((r) => r.kind === 'ad').map((r) => r.key);
+    expect(new Set(adKeys).size).toBe(adKeys.length);
+    expect(adKeys.every((k) => typeof k === 'string' && k.length > 0)).toBe(true);
+  });
+
+  it('treats invalid cadence (<= 0) as “no ads”', () => {
+    const items = make(20);
+    expect(interleaveAds(items, 0).every((r) => r.kind === 'item')).toBe(true);
+    expect(interleaveAds(items, -3).every((r) => r.kind === 'item')).toBe(true);
+  });
+});

--- a/src/lib/ads/interleaveAds.ts
+++ b/src/lib/ads/interleaveAds.ts
@@ -1,0 +1,19 @@
+export type FeedRow<T> =
+  | { kind: 'item'; item: T }
+  | { kind: 'ad'; key: string };
+
+export function interleaveAds<T>(items: ReadonlyArray<T>, cadence: number): FeedRow<T>[] {
+  if (items.length === 0) return [];
+  if (!Number.isFinite(cadence) || cadence <= 0) {
+    return items.map((item) => ({ kind: 'item', item }));
+  }
+
+  const rows: FeedRow<T>[] = [];
+  for (let i = 0; i < items.length; i += 1) {
+    if (i > 0 && i % cadence === 0) {
+      rows.push({ kind: 'ad', key: `ad-${i}` });
+    }
+    rows.push({ kind: 'item', item: items[i] });
+  }
+  return rows;
+}

--- a/src/screens/FeedScreen.test.tsx
+++ b/src/screens/FeedScreen.test.tsx
@@ -32,6 +32,15 @@ jest.mock('@/lib/users/avatarIdentity', () => ({
   ANIMAL_ASSETS: { fox: 1, bear: 2 },
 }));
 
+jest.mock('@/components/ads/TimelineBannerAd', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => React.createElement(View, { testID: 'timeline-banner-ad' }),
+  };
+});
+
 import { getFollowingUids } from '@/lib/users/follows';
 import { getFriendsFeed } from '@/lib/books/friendsFeed';
 
@@ -175,6 +184,50 @@ describe('FeedScreen — friend updates list', () => {
       expect(mockGetFriendsFeed).toHaveBeenCalledTimes(2);
       expect(mockGetFriendsFeed).toHaveBeenNthCalledWith(2, ['user2'], cursor);
     });
+  });
+});
+
+describe('FeedScreen — ad placement policy', () => {
+  const buildItems = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      ...mockActivity,
+      id: `act-${i}`,
+      title: `Book ${i}`,
+    }));
+
+  it('does not render an ad in the empty state', async () => {
+    mockGetFollowingUids.mockResolvedValue([]);
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('timeline.emptyBody'));
+    expect(screen.queryByTestId('timeline-banner-ad')).toBeNull();
+  });
+
+  it('does not render an ad in the error state', async () => {
+    mockGetFriendsFeed.mockRejectedValueOnce(new Error('boom'));
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('timeline.loadErrorBody'));
+    expect(screen.queryByTestId('timeline-banner-ad')).toBeNull();
+  });
+
+  it('does not render an ad while the feed is loading', () => {
+    mockGetFriendsFeed.mockReturnValue(new Promise(() => {}));
+    render(<FeedScreen />);
+    expect(screen.queryByTestId('timeline-banner-ad')).toBeNull();
+  });
+
+  it('does not render any ad when only a few items are present (< cadence)', async () => {
+    mockGetFriendsFeed.mockResolvedValue({ items: buildItems(5), lastDoc: null });
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Book 0'));
+    expect(screen.queryByTestId('timeline-banner-ad')).toBeNull();
+  });
+
+  it('renders one ad after the 6th item once the cadence is reached with more items following', async () => {
+    mockGetFriendsFeed.mockResolvedValue({ items: buildItems(13), lastDoc: null });
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Book 0'));
+    const ads = await screen.findAllByTestId('timeline-banner-ad');
+    expect(ads.length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -14,12 +14,15 @@ import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import ActivityDetailModal from '@/components/feed/ActivityDetailModal';
 import AddFriendButton from '@/components/feed/AddFriendButton';
+import TimelineBannerAd from '@/components/ads/TimelineBannerAd';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
 import { yomoyoColors, yomoyoTypography } from '@/constants/yomoyoTheme';
 import { ANIMAL_ASSETS } from '@/lib/users/avatarIdentity';
 import type { AnimalKey } from '@/lib/users/avatarIdentity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
 import type { RootStackParamList } from '@/navigation/types';
+import { interleaveAds, type FeedRow } from '@/lib/ads/interleaveAds';
+import { TIMELINE_AD_CADENCE } from '@/constants/ads';
 import { useFeedState } from './FeedScreen.hooks';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -83,6 +86,30 @@ export default function FeedScreen() {
     [navigation],
   );
 
+  const listData = useMemo<FeedRow<ReadingActivity>[]>(
+    () => interleaveAds(items, TIMELINE_AD_CADENCE),
+    [items],
+  );
+
+  const renderRow = useCallback(
+    ({ item: row }: { item: FeedRow<ReadingActivity> }) => {
+      if (row.kind === 'ad') {
+        return (
+          <View style={styles.adSlot}>
+            <TimelineBannerAd />
+          </View>
+        );
+      }
+      return <ActivityCard item={row.item} onPress={handleRowPress} />;
+    },
+    [handleRowPress],
+  );
+
+  const keyExtractor = useCallback(
+    (row: FeedRow<ReadingActivity>) => (row.kind === 'ad' ? row.key : row.item.id),
+    [],
+  );
+
   return (
     <ScreenContainer bottomInset={tabBarInset}>
       {isLoading ? (
@@ -101,13 +128,13 @@ export default function FeedScreen() {
       ) : (
         <FlatList
           testID="updates-list"
-          data={items}
-          keyExtractor={(item) => item.id}
+          data={listData}
+          keyExtractor={keyExtractor}
           contentContainerStyle={styles.list}
           onEndReached={handleLoadMore}
           onEndReachedThreshold={0.3}
           ListFooterComponent={isLoadingMore ? <ActivityIndicator style={styles.loader} /> : null}
-          renderItem={({ item }) => <ActivityCard item={item} onPress={handleRowPress} />}
+          renderItem={renderRow}
         />
       )}
 
@@ -136,6 +163,7 @@ const styles = StyleSheet.create({
   },
   list: { padding: 16 },
   loader: { marginVertical: 16 },
+  adSlot: { marginBottom: 12, alignItems: 'center' },
   card: {
     backgroundColor: yomoyoColors.surface,
     borderRadius: 12,

--- a/src/types/react-native-google-mobile-ads.d.ts
+++ b/src/types/react-native-google-mobile-ads.d.ts
@@ -1,0 +1,37 @@
+declare module 'react-native-google-mobile-ads' {
+  import type * as React from 'react';
+
+  export type BannerAdSizeValue =
+    | 'ANCHORED_ADAPTIVE_BANNER'
+    | 'BANNER'
+    | 'LARGE_BANNER'
+    | 'MEDIUM_RECTANGLE';
+
+  export const BannerAdSize: {
+    ANCHORED_ADAPTIVE_BANNER: 'ANCHORED_ADAPTIVE_BANNER';
+    BANNER: 'BANNER';
+    LARGE_BANNER: 'LARGE_BANNER';
+    MEDIUM_RECTANGLE: 'MEDIUM_RECTANGLE';
+  };
+
+  export const TestIds: {
+    BANNER: string;
+    INTERSTITIAL: string;
+    REWARDED: string;
+  };
+
+  export interface BannerAdProps {
+    unitId: string;
+    size: BannerAdSizeValue;
+  }
+
+  export const BannerAd: React.ComponentType<BannerAdProps>;
+
+  export interface MobileAdsInstance {
+    initialize: () => Promise<unknown>;
+    setRequestConfiguration: (config: Record<string, unknown>) => Promise<unknown>;
+  }
+
+  const mobileAds: () => MobileAdsInstance;
+  export default mobileAds;
+}


### PR DESCRIPTION
- Add react-native-google-mobile-ads dep, Expo plugin, and SDK init
- Place test BannerAd between Timeline items every 6 (never index 0)
- Skip ads in loading/empty/error states per emotional UX policy
- Test IDs only; ATT and real ad units are follow-up work