### PR TITLE
feat: add post-follow success state with Back to Timeline CTA

### DIFF
--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -63,6 +63,8 @@ const en = {
     notFound: 'This page does not exist.',
     emptyBooks: 'No finished books yet',
     ownPageNote: 'This is your page',
+    followSuccess: "You'll now see {{name}}'s reading on your Timeline.",
+    backToTimeline: 'Back to Timeline',
   },
   profile: {
     displayName: {

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -63,6 +63,8 @@ const ja = {
     notFound: 'このページは存在しません',
     emptyBooks: '読了した本はまだありません',
     ownPageNote: 'これはあなたのページです',
+    followSuccess: 'これから{{name}}さんの読書記録がタイムラインに届きます。',
+    backToTimeline: 'タイムラインに戻る',
   },
   profile: {
     displayName: {

--- a/src/screens/UserProfileScreen.test.tsx
+++ b/src/screens/UserProfileScreen.test.tsx
@@ -240,6 +240,79 @@ describe('UserProfileScreen — follow actions', () => {
   });
 });
 
+describe('UserProfileScreen — post-follow success state', () => {
+  it('does not show the success block before any follow action', async () => {
+    render(<UserProfileScreen />);
+    await screen.findByText('Quiet Fox');
+    expect(screen.queryByTestId('follow-success-block')).toBeNull();
+  });
+
+  it('does not show the success block when the user already follows this profile', async () => {
+    mockIsFollowing.mockResolvedValueOnce(true);
+    render(<UserProfileScreen />);
+    await screen.findByTestId('unfollow-button');
+    expect(screen.queryByTestId('follow-success-block')).toBeNull();
+  });
+
+  it('shows the success block after the user transitions from not-following to following', async () => {
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('follow-success-block')).toBeTruthy();
+    });
+  });
+
+  it('renders a back-to-timeline CTA inside the success block', async () => {
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    expect(await screen.findByTestId('back-to-timeline-button')).toBeTruthy();
+  });
+
+  it('navigates to the Timeline tab when the back-to-timeline CTA is pressed', async () => {
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    fireEvent.press(await screen.findByTestId('back-to-timeline-button'));
+    expect(mockNavigate).toHaveBeenCalledWith('MainTabs', { screen: 'Timeline' });
+  });
+
+  it('keeps the unfollow button accessible underneath the success block', async () => {
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    await screen.findByTestId('follow-success-block');
+    expect(screen.getByTestId('unfollow-button')).toBeTruthy();
+  });
+
+  it('hides the success block if the user immediately unfollows', async () => {
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    fireEvent.press(await screen.findByTestId('unfollow-button'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('follow-success-block')).toBeNull();
+    });
+  });
+
+  it('does not show the success block if followUser rejects', async () => {
+    mockFollowUser.mockRejectedValueOnce(new Error('network error'));
+    render(<UserProfileScreen />);
+    fireEvent.press(await screen.findByTestId('follow-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('follow-button')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('follow-success-block')).toBeNull();
+  });
+
+  it('does not show the success block on own profile', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      params: { uid: 'user1' },
+      key: 'UserProfile',
+      name: 'UserProfile',
+    });
+    render(<UserProfileScreen />);
+    await screen.findByText('userProfile.ownPageNote');
+    expect(screen.queryByTestId('follow-success-block')).toBeNull();
+  });
+});
+
 describe('UserProfileScreen — navigation button', () => {
   it('renders a navigation button', async () => {
     render(<UserProfileScreen />);

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -34,6 +34,7 @@ export default function UserProfileScreen() {
   const [identity, setIdentity] = useState<IdentityState>('loading');
   const [activities, setActivities] = useState<ReadingActivity[]>([]);
   const [following, setFollowing] = useState(false);
+  const [justFollowed, setJustFollowed] = useState(false);
 
   const isOwnProfile = user?.uid === uid;
 
@@ -85,12 +86,23 @@ export default function UserProfileScreen() {
     if (!user) return;
     if (following) {
       setFollowing(false);
+      setJustFollowed(false);
       unfollowUser(user.uid, uid).catch(() => setFollowing(true));
     } else {
       setFollowing(true);
-      followUser(user.uid, uid).catch(() => setFollowing(false));
+      setJustFollowed(true);
+      followUser(user.uid, uid).catch(() => {
+        setFollowing(false);
+        setJustFollowed(false);
+      });
     }
   };
+
+  const handleBackToTimeline = () => {
+    navigation.navigate('MainTabs', { screen: 'Timeline' });
+  };
+
+  const showFollowSuccess = !isOwnProfile && following && justFollowed;
 
   return (
     <ScreenContainer>
@@ -127,17 +139,37 @@ export default function UserProfileScreen() {
             </View>
           </View>
         ) : (
-          <PressableSurface
-            style={[styles.followButton, following && styles.followButtonActive]}
-            onPress={handleFollowToggle}
-            accessibilityRole="button"
-            testID={following ? 'unfollow-button' : 'follow-button'}
-            feedback="confirming"
-          >
-            <Text style={[styles.followButtonText, following && styles.followButtonTextActive]}>
-              {following ? t('userProfile.unfollow') : t('userProfile.follow')}
-            </Text>
-          </PressableSurface>
+          <>
+            {showFollowSuccess && (
+              <View testID="follow-success-block" style={styles.successBlock}>
+                <Text style={styles.successMessage}>
+                  {t('userProfile.followSuccess', { name: identity.displayName })}
+                </Text>
+                <PressableSurface
+                  style={styles.backToTimelineButton}
+                  onPress={handleBackToTimeline}
+                  accessibilityRole="button"
+                  testID="back-to-timeline-button"
+                  feedback="confirming"
+                >
+                  <Text style={styles.backToTimelineText}>
+                    {t('userProfile.backToTimeline')}
+                  </Text>
+                </PressableSurface>
+              </View>
+            )}
+            <PressableSurface
+              style={[styles.followButton, following && styles.followButtonActive]}
+              onPress={handleFollowToggle}
+              accessibilityRole="button"
+              testID={following ? 'unfollow-button' : 'follow-button'}
+              feedback="confirming"
+            >
+              <Text style={[styles.followButtonText, following && styles.followButtonTextActive]}>
+                {following ? t('userProfile.unfollow') : t('userProfile.follow')}
+              </Text>
+            </PressableSurface>
+          </>
         )}
 
         <Text style={styles.sectionHeader}>{t('shelf.finished')}</Text>
@@ -223,6 +255,38 @@ const makeStyles = (colors: ThemeColors) =>
       fontSize: yomoyoTypography.screenTitleSize,
       fontWeight: yomoyoTypography.titleWeight,
       color: colors.text,
+    },
+    successBlock: {
+      alignSelf: 'stretch',
+      marginHorizontal: 24,
+      marginBottom: 16,
+      paddingVertical: 16,
+      paddingHorizontal: 16,
+      borderRadius: 12,
+      backgroundColor: colors.surface,
+      alignItems: 'center',
+      shadowColor: colors.text,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.06,
+      shadowRadius: 4,
+      elevation: 2,
+    },
+    successMessage: {
+      fontSize: yomoyoTypography.screenBodySize,
+      color: colors.text,
+      textAlign: 'center',
+      marginBottom: 12,
+    },
+    backToTimelineButton: {
+      borderRadius: 24,
+      backgroundColor: colors.primary,
+      paddingVertical: 10,
+      paddingHorizontal: 24,
+    },
+    backToTimelineText: {
+      fontSize: yomoyoTypography.screenBodySize,
+      fontWeight: yomoyoTypography.buttonWeight,
+      color: colors.surface,
     },
     followButton: {
       alignSelf: 'center',


### PR DESCRIPTION
Show a session-scoped success block on UserProfileScreen when the user transitions from not-following to following, with a primary CTA that returns to the Timeline tab. Unfollow stays accessible underneath so the action remains reversible.