### PR TITLE
fix: refresh timeline identity from current user doc

### DIFF
--- a/src/lib/books/enrichActivityAvatars.test.ts
+++ b/src/lib/books/enrichActivityAvatars.test.ts
@@ -1,8 +1,7 @@
 import { enrichActivityAvatars } from './enrichActivityAvatars';
+import type { AvatarCache } from './enrichActivityAvatars';
 import type { ReadingActivity } from './readingActivity';
 import type { AnimalKey } from '@/lib/users/avatarIdentity';
-
-type AvatarCache = Map<string, AnimalKey | null>;
 
 const baseItem = (overrides: Partial<ReadingActivity>): ReadingActivity => ({
   id: 'a1',
@@ -18,87 +17,101 @@ const baseItem = (overrides: Partial<ReadingActivity>): ReadingActivity => ({
   ...overrides,
 });
 
-const fakeIdentity = (animalKey: AnimalKey) => ({
+const fakeIdentity = (animalKey: AnimalKey, displayName = 'Resolved Name') => ({
   animalKey,
-  displayName: 'Whatever',
+  displayName,
   finalizedAt: null,
 });
 
 describe('enrichActivityAvatars', () => {
-  it('returns items unchanged when displayAvatar is already set', async () => {
-    const items = [baseItem({ displayAvatar: 'fox' })];
-    const getAvatar = jest.fn();
-    const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
-    expect(result[0].displayAvatar).toBe('fox');
-    expect(getAvatar).not.toHaveBeenCalled();
-  });
-
-  it('looks up the avatar when displayAvatar is missing', async () => {
-    const items = [baseItem({ displayAvatar: null })];
-    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear'));
+  it('overrides displayAvatar with the current identity even when it is already set', async () => {
+    const items = [baseItem({ displayAvatar: 'eagle', displayName: 'Old Name' })];
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear', 'Current Name'));
     const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
     expect(result[0].displayAvatar).toBe('bear');
     expect(getAvatar).toHaveBeenCalledWith('u1');
   });
 
+  it('overrides displayName with the current identity', async () => {
+    const items = [baseItem({ displayName: 'Old Name', displayAvatar: 'eagle' })];
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear', 'Current Name'));
+    const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
+    expect(result[0].displayName).toBe('Current Name');
+  });
+
+  it('fills in displayAvatar when it is missing and the identity resolves', async () => {
+    const items = [baseItem({ displayAvatar: null })];
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear'));
+    const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
+    expect(result[0].displayAvatar).toBe('bear');
+  });
+
   it('dedupes lookups when multiple items share a userId', async () => {
     const items = [
-      baseItem({ id: 'a1', userId: 'u1', displayAvatar: null }),
-      baseItem({ id: 'a2', userId: 'u1', displayAvatar: null }),
+      baseItem({ id: 'a1', userId: 'u1', displayAvatar: 'eagle' }),
+      baseItem({ id: 'a2', userId: 'u1', displayAvatar: 'eagle' }),
     ];
-    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear'));
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear', 'New'));
     const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
     expect(getAvatar).toHaveBeenCalledTimes(1);
     expect(result[0].displayAvatar).toBe('bear');
     expect(result[1].displayAvatar).toBe('bear');
+    expect(result[0].displayName).toBe('New');
+    expect(result[1].displayName).toBe('New');
   });
 
-  it('uses cache to skip already-resolved userIds', async () => {
-    const cache: AvatarCache = new Map([['u1', 'wolf' as AnimalKey]]);
-    const items = [baseItem({ displayAvatar: null })];
+  it('uses the cache to skip already-resolved userIds', async () => {
+    const cache: AvatarCache = new Map([
+      ['u1', { animalKey: 'wolf', displayName: 'Cached Name' }],
+    ]);
+    const items = [baseItem({ displayAvatar: 'eagle', displayName: 'Stale' })];
     const getAvatar = jest.fn();
     const result = await enrichActivityAvatars(items, cache, getAvatar);
     expect(result[0].displayAvatar).toBe('wolf');
+    expect(result[0].displayName).toBe('Cached Name');
     expect(getAvatar).not.toHaveBeenCalled();
   });
 
-  it('writes a cache entry per resolved userId so later calls can reuse it', async () => {
+  it('writes a full identity snapshot to the cache per resolved userId', async () => {
     const cache: AvatarCache = new Map();
     const items = [baseItem({ displayAvatar: null })];
-    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear'));
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear', 'Resolved'));
     await enrichActivityAvatars(items, cache, getAvatar);
-    expect(cache.get('u1')).toBe('bear');
+    expect(cache.get('u1')).toEqual({ animalKey: 'bear', displayName: 'Resolved' });
   });
 
-  it('keeps displayAvatar as null when lookup fails', async () => {
-    const items = [baseItem({ displayAvatar: null })];
+  it('keeps the original item when the lookup fails', async () => {
+    const items = [baseItem({ displayAvatar: 'eagle', displayName: 'Original' })];
     const getAvatar = jest.fn().mockRejectedValue(new Error('boom'));
     const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
-    expect(result[0].displayAvatar).toBeNull();
+    expect(result[0].displayAvatar).toBe('eagle');
+    expect(result[0].displayName).toBe('Original');
   });
 
   it('caches null for failed lookups so we do not retry within the same session', async () => {
     const cache: AvatarCache = new Map();
-    const items = [baseItem({ displayAvatar: null })];
+    const items = [baseItem({ displayAvatar: 'eagle' })];
     const getAvatar = jest.fn().mockRejectedValue(new Error('boom'));
     await enrichActivityAvatars(items, cache, getAvatar);
     expect(cache.has('u1')).toBe(true);
     expect(cache.get('u1')).toBeNull();
   });
 
-  it('keeps displayAvatar as null when lookup returns null (no identity yet)', async () => {
-    const items = [baseItem({ displayAvatar: null })];
+  it('keeps the original item when the identity lookup returns null', async () => {
+    const items = [baseItem({ displayAvatar: 'eagle', displayName: 'Original' })];
     const getAvatar = jest.fn().mockResolvedValue(null);
     const result = await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
-    expect(result[0].displayAvatar).toBeNull();
+    expect(result[0].displayAvatar).toBe('eagle');
+    expect(result[0].displayName).toBe('Original');
   });
 
-  it('returns the original items reference shape (does not mutate inputs)', async () => {
-    const original = baseItem({ displayAvatar: null });
+  it('does not mutate the input items', async () => {
+    const original = baseItem({ displayAvatar: 'eagle', displayName: 'Original' });
     const items = [original];
-    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear'));
+    const getAvatar = jest.fn().mockResolvedValue(fakeIdentity('bear', 'New'));
     await enrichActivityAvatars(items, new Map() as AvatarCache, getAvatar);
-    expect(original.displayAvatar).toBeNull();
+    expect(original.displayAvatar).toBe('eagle');
+    expect(original.displayName).toBe('Original');
   });
 
   it('returns an empty array when given an empty array', async () => {

--- a/src/lib/books/enrichActivityAvatars.ts
+++ b/src/lib/books/enrichActivityAvatars.ts
@@ -1,7 +1,12 @@
 import type { ReadingActivity } from './readingActivity';
 import type { AnimalKey, AvatarIdentity } from '@/lib/users/avatarIdentity';
 
-export type AvatarCache = Map<string, AnimalKey | null>;
+export type IdentitySnapshot = {
+  animalKey: AnimalKey;
+  displayName: string;
+};
+
+export type AvatarCache = Map<string, IdentitySnapshot | null>;
 
 type GetAvatarIdentity = (userId: string) => Promise<AvatarIdentity | null>;
 
@@ -14,7 +19,7 @@ export async function enrichActivityAvatars(
 
   const missingUserIds = new Set<string>();
   for (const item of items) {
-    if (!item.displayAvatar && !cache.has(item.userId)) {
+    if (!cache.has(item.userId)) {
       missingUserIds.add(item.userId);
     }
   }
@@ -24,7 +29,12 @@ export async function enrichActivityAvatars(
       Array.from(missingUserIds).map(async (userId) => {
         try {
           const identity = await getAvatarIdentity(userId);
-          cache.set(userId, identity?.animalKey ?? null);
+          cache.set(
+            userId,
+            identity
+              ? { animalKey: identity.animalKey, displayName: identity.displayName }
+              : null,
+          );
         } catch {
           cache.set(userId, null);
         }
@@ -33,9 +43,12 @@ export async function enrichActivityAvatars(
   }
 
   return items.map((item) => {
-    if (item.displayAvatar) return item;
     const resolved = cache.get(item.userId) ?? null;
     if (resolved === null) return item;
-    return { ...item, displayAvatar: resolved };
+    return {
+      ...item,
+      displayAvatar: resolved.animalKey,
+      displayName: resolved.displayName,
+    };
   });
 }


### PR DESCRIPTION
Activity docs persist a snapshot of displayName/displayAvatar at finish time, leaving the timeline stuck on stale or invalid values when the user later changes their identity (or when a legacy doc holds a non-AnimalKey string like a Google photoURL).

enrichActivityAvatars now looks up the owning user's current identity for every activity and overrides both displayName and displayAvatar. Lookup failures fall back to existing values.

Trade-off: the timeline reflects each user's current identity rather than a historical snapshot - accepted in lieu of a Firestore backfill.