### PR TITLE
feat: add private bookmarks to timeline

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,11 @@ service cloud.firestore {
       match /pushTokens/{tokenId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
+
+      // Bookmarks are private to the user — never readable by anyone else.
+      match /bookmarks/{activityId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Handle reservations: maps a human-readable handle to its owner uid.

--- a/src/components/feed/ActivityBookmarkButton.test.tsx
+++ b/src/components/feed/ActivityBookmarkButton.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { screen, fireEvent, act } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import ActivityBookmarkButton from './ActivityBookmarkButton';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('ActivityBookmarkButton', () => {
+  it('renders with the off (outline) icon when bookmarked=false', () => {
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={false} onToggle={() => {}} />);
+    const button = screen.getByTestId('bookmark-toggle-act1');
+    expect(button).toBeTruthy();
+    expect(button.props.accessibilityState?.selected).toBe(false);
+  });
+
+  it('renders the on (filled) state when bookmarked=true', () => {
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={true} onToggle={() => {}} />);
+    const button = screen.getByTestId('bookmark-toggle-act1');
+    expect(button.props.accessibilityState?.selected).toBe(true);
+  });
+
+  it('uses the add label when not bookmarked', () => {
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={false} onToggle={() => {}} />);
+    expect(screen.getByTestId('bookmark-toggle-act1').props.accessibilityLabel).toBe(
+      'timeline.bookmarkAdd',
+    );
+  });
+
+  it('uses the remove label when bookmarked', () => {
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={true} onToggle={() => {}} />);
+    expect(screen.getByTestId('bookmark-toggle-act1').props.accessibilityLabel).toBe(
+      'timeline.bookmarkRemove',
+    );
+  });
+
+  it('calls onToggle with the activity id when pressed', () => {
+    const onToggle = jest.fn();
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={false} onToggle={onToggle} />);
+    act(() => {
+      fireEvent.press(screen.getByTestId('bookmark-toggle-act1'));
+    });
+    expect(onToggle).toHaveBeenCalledWith('act1');
+  });
+
+  it('exposes button accessibility role for screen readers', () => {
+    render(<ActivityBookmarkButton activityId="act1" bookmarked={false} onToggle={() => {}} />);
+    const button = screen.getByTestId('bookmark-toggle-act1');
+    expect(button.props.accessibilityRole).toBe('button');
+  });
+});

--- a/src/components/feed/ActivityBookmarkButton.tsx
+++ b/src/components/feed/ActivityBookmarkButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import PressableSurface from '@/components/ui/PressableSurface';
+import { useTheme } from '@/lib/theme';
+
+type Props = {
+  activityId: string;
+  bookmarked: boolean;
+  onToggle: (activityId: string) => void;
+};
+
+export default function ActivityBookmarkButton({ activityId, bookmarked, onToggle }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const label = bookmarked ? t('timeline.bookmarkRemove') : t('timeline.bookmarkAdd');
+
+  return (
+    <PressableSurface
+      testID={`bookmark-toggle-${activityId}`}
+      onPress={() => onToggle(activityId)}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: bookmarked }}
+      style={styles.button}
+      hitSlop={8}
+      feedback="soft"
+    >
+      <Ionicons
+        name={bookmarked ? 'bookmark' : 'bookmark-outline'}
+        size={20}
+        color={bookmarked ? colors.primary : colors.muted}
+      />
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    padding: 6,
+  },
+});

--- a/src/components/feed/BookmarkFilterToggle.test.tsx
+++ b/src/components/feed/BookmarkFilterToggle.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { screen, fireEvent, act } from '@testing-library/react-native';
+import { renderWithTheme } from '@/lib/theme/testUtils';
+import { BookmarkFilterProvider, useBookmarkFilter } from '@/lib/books/bookmarkFilterContext';
+import BookmarkFilterToggle from './BookmarkFilterToggle';
+import { Text } from 'react-native';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function ModeProbe() {
+  const { mode } = useBookmarkFilter();
+  return <Text testID="mode-readout">{mode}</Text>;
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return renderWithTheme(<BookmarkFilterProvider>{ui}</BookmarkFilterProvider>);
+}
+
+describe('BookmarkFilterToggle', () => {
+  it('renders with selected=false while mode is "all"', () => {
+    renderWithProvider(<BookmarkFilterToggle />);
+    expect(screen.getByTestId('bookmark-filter-toggle').props.accessibilityState?.selected).toBe(
+      false,
+    );
+  });
+
+  it('uses the filterBookmarks label when mode is "all"', () => {
+    renderWithProvider(<BookmarkFilterToggle />);
+    expect(screen.getByTestId('bookmark-filter-toggle').props.accessibilityLabel).toBe(
+      'timeline.filterBookmarks',
+    );
+  });
+
+  it('flips the filter mode when pressed', () => {
+    renderWithProvider(
+      <>
+        <ModeProbe />
+        <BookmarkFilterToggle />
+      </>,
+    );
+    expect(screen.getByTestId('mode-readout').props.children).toBe('all');
+    act(() => {
+      fireEvent.press(screen.getByTestId('bookmark-filter-toggle'));
+    });
+    expect(screen.getByTestId('mode-readout').props.children).toBe('bookmarks');
+    expect(screen.getByTestId('bookmark-filter-toggle').props.accessibilityState?.selected).toBe(
+      true,
+    );
+    expect(screen.getByTestId('bookmark-filter-toggle').props.accessibilityLabel).toBe(
+      'timeline.filterAll',
+    );
+  });
+});

--- a/src/components/feed/BookmarkFilterToggle.tsx
+++ b/src/components/feed/BookmarkFilterToggle.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import PressableSurface from '@/components/ui/PressableSurface';
+import { useTheme } from '@/lib/theme';
+import { useBookmarkFilter } from '@/lib/books/bookmarkFilterContext';
+
+export default function BookmarkFilterToggle() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const { mode, toggle } = useBookmarkFilter();
+  const isBookmarksOnly = mode === 'bookmarks';
+  const label = isBookmarksOnly ? t('timeline.filterAll') : t('timeline.filterBookmarks');
+
+  return (
+    <PressableSurface
+      testID="bookmark-filter-toggle"
+      onPress={toggle}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: isBookmarksOnly }}
+      style={styles.button}
+      hitSlop={8}
+      feedback="standard"
+    >
+      <Ionicons
+        name={isBookmarksOnly ? 'bookmark' : 'bookmark-outline'}
+        size={22}
+        color={isBookmarksOnly ? colors.primary : colors.text}
+      />
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+});

--- a/src/lib/books/bookmarkFilterContext.test.tsx
+++ b/src/lib/books/bookmarkFilterContext.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Text, Pressable } from 'react-native';
+import { render, screen, fireEvent, act } from '@testing-library/react-native';
+import {
+  BookmarkFilterProvider,
+  useBookmarkFilter,
+} from './bookmarkFilterContext';
+
+function Probe() {
+  const { mode, setMode, toggle } = useBookmarkFilter();
+  return (
+    <>
+      <Text testID="mode">{mode}</Text>
+      <Pressable testID="set-bookmarks" onPress={() => setMode('bookmarks')}>
+        <Text>set</Text>
+      </Pressable>
+      <Pressable testID="toggle" onPress={() => toggle()}>
+        <Text>toggle</Text>
+      </Pressable>
+    </>
+  );
+}
+
+describe('BookmarkFilterProvider', () => {
+  it('respects initialMode when provided (for tests / restore-state scenarios)', () => {
+    render(
+      <BookmarkFilterProvider initialMode="bookmarks">
+        <Probe />
+      </BookmarkFilterProvider>,
+    );
+    expect(screen.getByTestId('mode').props.children).toBe('bookmarks');
+  });
+
+  it('defaults to "all" mode on first render', () => {
+    render(
+      <BookmarkFilterProvider>
+        <Probe />
+      </BookmarkFilterProvider>,
+    );
+    expect(screen.getByTestId('mode').props.children).toBe('all');
+  });
+
+  it('updates the mode when setMode is called', () => {
+    render(
+      <BookmarkFilterProvider>
+        <Probe />
+      </BookmarkFilterProvider>,
+    );
+    act(() => {
+      fireEvent.press(screen.getByTestId('set-bookmarks'));
+    });
+    expect(screen.getByTestId('mode').props.children).toBe('bookmarks');
+  });
+
+  it('flips the mode when toggle is called', () => {
+    render(
+      <BookmarkFilterProvider>
+        <Probe />
+      </BookmarkFilterProvider>,
+    );
+    act(() => fireEvent.press(screen.getByTestId('toggle')));
+    expect(screen.getByTestId('mode').props.children).toBe('bookmarks');
+    act(() => fireEvent.press(screen.getByTestId('toggle')));
+    expect(screen.getByTestId('mode').props.children).toBe('all');
+  });
+});
+
+describe('useBookmarkFilter outside provider', () => {
+  it('throws a clear error when used without a provider', () => {
+    // Silence React's console.error from the boundary
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<Probe />)).toThrow(/BookmarkFilterProvider/);
+    spy.mockRestore();
+  });
+});

--- a/src/lib/books/bookmarkFilterContext.tsx
+++ b/src/lib/books/bookmarkFilterContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+export type BookmarkFilterMode = 'all' | 'bookmarks';
+
+type BookmarkFilterContextValue = {
+  mode: BookmarkFilterMode;
+  setMode: (mode: BookmarkFilterMode) => void;
+  toggle: () => void;
+};
+
+const BookmarkFilterContext = createContext<BookmarkFilterContextValue | null>(null);
+
+type ProviderProps = {
+  children: React.ReactNode;
+  initialMode?: BookmarkFilterMode;
+};
+
+export function BookmarkFilterProvider({ children, initialMode = 'all' }: ProviderProps) {
+  const [mode, setMode] = useState<BookmarkFilterMode>(initialMode);
+
+  const toggle = useCallback(() => {
+    setMode((prev) => (prev === 'all' ? 'bookmarks' : 'all'));
+  }, []);
+
+  const value = useMemo<BookmarkFilterContextValue>(
+    () => ({ mode, setMode, toggle }),
+    [mode, toggle],
+  );
+
+  return (
+    <BookmarkFilterContext.Provider value={value}>{children}</BookmarkFilterContext.Provider>
+  );
+}
+
+export function useBookmarkFilter(): BookmarkFilterContextValue {
+  const ctx = useContext(BookmarkFilterContext);
+  if (!ctx) {
+    throw new Error('useBookmarkFilter must be used inside a BookmarkFilterProvider');
+  }
+  return ctx;
+}

--- a/src/lib/books/bookmarks.test.ts
+++ b/src/lib/books/bookmarks.test.ts
@@ -1,0 +1,284 @@
+import {
+  addBookmark,
+  removeBookmark,
+  getBookmarkIds,
+  getBookmarkedActivities,
+} from './bookmarks';
+import {
+  collection,
+  doc,
+  setDoc,
+  deleteDoc,
+  getDoc,
+  getDocs,
+  orderBy,
+  limit,
+  startAfter,
+  serverTimestamp,
+} from 'firebase/firestore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('addBookmark', () => {
+  it('writes to the per-user bookmarks subcollection', async () => {
+    await addBookmark('user1', 'act1');
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(
+      expect.anything(),
+      'users',
+      'user1',
+      'bookmarks',
+      'act1',
+    );
+  });
+
+  it('stores the activityId field for read-back convenience', async () => {
+    await addBookmark('user1', 'act1');
+    expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ activityId: 'act1' }),
+    );
+  });
+
+  it('includes a bookmarkedAt server timestamp', async () => {
+    await addBookmark('user1', 'act1');
+    expect(jest.mocked(setDoc)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ bookmarkedAt: expect.anything() }),
+    );
+    expect(jest.mocked(serverTimestamp)).toHaveBeenCalled();
+  });
+});
+
+describe('removeBookmark', () => {
+  it('deletes the bookmark document at the per-user path', async () => {
+    await removeBookmark('user1', 'act1');
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(
+      expect.anything(),
+      'users',
+      'user1',
+      'bookmarks',
+      'act1',
+    );
+    expect(jest.mocked(deleteDoc)).toHaveBeenCalled();
+  });
+});
+
+describe('getBookmarkIds', () => {
+  it('queries the per-user bookmarks subcollection', async () => {
+    await getBookmarkIds('user1');
+    expect(jest.mocked(collection)).toHaveBeenCalledWith(
+      expect.anything(),
+      'users',
+      'user1',
+      'bookmarks',
+    );
+  });
+
+  it('returns a Set of activity IDs from the doc ids', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        { id: 'act1', data: () => ({ activityId: 'act1' }) },
+        { id: 'act2', data: () => ({ activityId: 'act2' }) },
+      ],
+    } as any);
+
+    const result = await getBookmarkIds('user1');
+    expect(result).toBeInstanceOf(Set);
+    expect(result.has('act1')).toBe(true);
+    expect(result.has('act2')).toBe(true);
+    expect(result.size).toBe(2);
+  });
+
+  it('returns an empty Set when the user has no bookmarks', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    const result = await getBookmarkIds('user1');
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('getBookmarkedActivities', () => {
+  it('returns an empty page when there are no bookmark docs', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    const result = await getBookmarkedActivities('user1', null);
+    expect(result).toEqual({ items: [], lastDoc: null });
+  });
+
+  it('queries the per-user bookmarks subcollection', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    await getBookmarkedActivities('user1', null);
+    expect(jest.mocked(collection)).toHaveBeenCalledWith(
+      expect.anything(),
+      'users',
+      'user1',
+      'bookmarks',
+    );
+  });
+
+  it('orders by bookmarkedAt descending', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    await getBookmarkedActivities('user1', null);
+    expect(jest.mocked(orderBy)).toHaveBeenCalledWith('bookmarkedAt', 'desc');
+  });
+
+  it('applies a default page size limit', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    await getBookmarkedActivities('user1', null);
+    expect(jest.mocked(limit)).toHaveBeenCalled();
+  });
+
+  it('does not call startAfter when cursor is null', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    await getBookmarkedActivities('user1', null);
+    expect(jest.mocked(startAfter)).not.toHaveBeenCalled();
+  });
+
+  it('applies startAfter when a cursor is provided', async () => {
+    const cursor = { id: 'cursor-doc' } as any;
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    await getBookmarkedActivities('user1', cursor);
+    expect(jest.mocked(startAfter)).toHaveBeenCalledWith(cursor);
+  });
+
+  it('resolves each bookmark to its readingActivities document', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        { id: 'act1', data: () => ({ activityId: 'act1' }) },
+      ],
+    } as any);
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      id: 'act1',
+      data: () => ({
+        userId: 'user2',
+        bookId: 'book1',
+        title: 'Dune',
+        authors: ['Frank Herbert'],
+        thumbnail: null,
+        status: 'finished',
+        finishedAt: null,
+        displayName: 'Bold Bear',
+        displayAvatar: 'bear',
+      }),
+    } as any);
+
+    const result = await getBookmarkedActivities('user1', null);
+    expect(jest.mocked(doc)).toHaveBeenCalledWith(
+      expect.anything(),
+      'readingActivities',
+      'act1',
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: 'act1',
+      title: 'Dune',
+      userId: 'user2',
+    });
+  });
+
+  it('silently skips bookmarks whose activity has been deleted', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        { id: 'act1', data: () => ({ activityId: 'act1' }) },
+        { id: 'act2', data: () => ({ activityId: 'act2' }) },
+      ],
+    } as any);
+    jest
+      .mocked(getDoc)
+      .mockResolvedValueOnce({
+        exists: () => false,
+        id: 'act1',
+        data: () => undefined,
+      } as any)
+      .mockResolvedValueOnce({
+        exists: () => true,
+        id: 'act2',
+        data: () => ({
+          userId: 'user2',
+          bookId: 'book2',
+          title: 'Kindred',
+          authors: ['Octavia Butler'],
+          thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
+          displayName: 'Quiet Fox',
+          displayAvatar: 'fox',
+        }),
+      } as any);
+
+    const result = await getBookmarkedActivities('user1', null);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe('act2');
+  });
+
+  it('preserves bookmark order even if one fetch is slower than another', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({
+      docs: [
+        { id: 'first', data: () => ({ activityId: 'first' }) },
+        { id: 'second', data: () => ({ activityId: 'second' }) },
+      ],
+    } as any);
+    jest
+      .mocked(getDoc)
+      .mockResolvedValueOnce({
+        exists: () => true,
+        id: 'first',
+        data: () => ({
+          userId: 'u',
+          bookId: 'b1',
+          title: 'A',
+          authors: [],
+          thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        exists: () => true,
+        id: 'second',
+        data: () => ({
+          userId: 'u',
+          bookId: 'b2',
+          title: 'B',
+          authors: [],
+          thumbnail: null,
+          status: 'finished',
+          finishedAt: null,
+        }),
+      } as any);
+
+    const result = await getBookmarkedActivities('user1', null);
+    expect(result.items.map((i) => i.id)).toEqual(['first', 'second']);
+  });
+
+  it('returns lastDoc as the last bookmark doc snapshot for pagination', async () => {
+    const lastBookmarkDoc = {
+      id: 'act-last',
+      data: () => ({ activityId: 'act-last' }),
+    };
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [lastBookmarkDoc] } as any);
+    jest.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      id: 'act-last',
+      data: () => ({
+        userId: 'u',
+        bookId: 'b',
+        title: 't',
+        authors: [],
+        thumbnail: null,
+        status: 'finished',
+        finishedAt: null,
+      }),
+    } as any);
+
+    const result = await getBookmarkedActivities('user1', null);
+    expect(result.lastDoc).toBe(lastBookmarkDoc);
+  });
+
+  it('returns lastDoc null when no bookmarks were fetched', async () => {
+    jest.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as any);
+    const result = await getBookmarkedActivities('user1', null);
+    expect(result.lastDoc).toBeNull();
+  });
+});

--- a/src/lib/books/bookmarks.ts
+++ b/src/lib/books/bookmarks.ts
@@ -1,0 +1,83 @@
+import {
+  getFirestore,
+  collection,
+  doc,
+  setDoc,
+  deleteDoc,
+  getDoc,
+  getDocs,
+  query,
+  orderBy,
+  limit,
+  startAfter,
+  serverTimestamp,
+} from 'firebase/firestore';
+import type { QueryDocumentSnapshot } from 'firebase/firestore';
+import type { ReadingActivity } from './readingActivity';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export type BookmarkPage = {
+  items: ReadingActivity[];
+  lastDoc: QueryDocumentSnapshot | null;
+};
+
+function bookmarkDoc(uid: string, activityId: string) {
+  const db = getFirestore();
+  return doc(db, 'users', uid, 'bookmarks', activityId);
+}
+
+function bookmarkCollection(uid: string) {
+  const db = getFirestore();
+  return collection(db, 'users', uid, 'bookmarks');
+}
+
+export async function addBookmark(uid: string, activityId: string): Promise<void> {
+  await setDoc(bookmarkDoc(uid, activityId), {
+    activityId,
+    bookmarkedAt: serverTimestamp(),
+  });
+}
+
+export async function removeBookmark(uid: string, activityId: string): Promise<void> {
+  await deleteDoc(bookmarkDoc(uid, activityId));
+}
+
+export async function getBookmarkIds(uid: string): Promise<Set<string>> {
+  const snapshot = await getDocs(bookmarkCollection(uid));
+  return new Set(snapshot.docs.map((d) => d.id));
+}
+
+export async function getBookmarkedActivities(
+  uid: string,
+  cursor: QueryDocumentSnapshot | null,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): Promise<BookmarkPage> {
+  const baseQuery = query(
+    bookmarkCollection(uid),
+    orderBy('bookmarkedAt', 'desc'),
+    limit(pageSize),
+  );
+  const q = cursor ? query(baseQuery, startAfter(cursor)) : baseQuery;
+  const snapshot = await getDocs(q);
+  if (snapshot.docs.length === 0) {
+    return { items: [], lastDoc: null };
+  }
+
+  const db = getFirestore();
+  const activitySnaps = await Promise.all(
+    snapshot.docs.map((bookmark) => getDoc(doc(db, 'readingActivities', bookmark.id))),
+  );
+
+  const items: ReadingActivity[] = [];
+  activitySnaps.forEach((snap) => {
+    if (!snap.exists()) return;
+    items.push({
+      id: snap.id,
+      ...(snap.data() as Omit<ReadingActivity, 'id'>),
+    });
+  });
+
+  const lastDoc = (snapshot.docs[snapshot.docs.length - 1] as QueryDocumentSnapshot) ?? null;
+  return { items, lastDoc };
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -9,9 +9,14 @@ const en = {
   timeline: {
     finishedReading: 'Finished reading',
     emptyBody: 'Reading records from your friends will appear here.',
+    emptyBookmarks: 'No bookmarks yet. Tap the bookmark icon on a card to save it.',
     loadErrorBody: 'Something went wrong. Please try again.',
     modalViewProfile: 'View profile',
     modalClose: 'Close',
+    bookmarkAdd: 'Save bookmark',
+    bookmarkRemove: 'Remove bookmark',
+    filterBookmarks: 'Show bookmarks only',
+    filterAll: 'Show all',
   },
   addFriend: {
     heading: 'Add a friend',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -9,9 +9,14 @@ const ja = {
   timeline: {
     finishedReading: '読み終えました',
     emptyBody: '友達の読了した記録が表示されます。',
+    emptyBookmarks: 'ブックマークはまだありません。気になる本のしおりアイコンを押して保存できます。',
     loadErrorBody: '読み込みに失敗しました。もう一度お試しください。',
     modalViewProfile: 'プロフィールを見る',
     modalClose: '閉じる',
+    bookmarkAdd: 'ブックマークに追加',
+    bookmarkRemove: 'ブックマークを外す',
+    filterBookmarks: 'ブックマークのみ表示',
+    filterAll: 'すべて表示',
   },
   addFriend: {
     heading: '友達を追加',

--- a/src/navigation/MainTabNavigator.test.tsx
+++ b/src/navigation/MainTabNavigator.test.tsx
@@ -63,6 +63,15 @@ jest.mock('@/screens/FeedScreen', () => () => null);
 jest.mock('@/screens/ShelfScreen', () => () => null);
 jest.mock('@/components/feed/AddFriendButton', () => () => null);
 jest.mock('@/components/settings/SettingsLauncher', () => () => null);
+jest.mock('@/components/feed/BookmarkFilterToggle', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      React.createElement(View, { testID: 'bookmark-filter-toggle-mock' }),
+  };
+});
 
 beforeEach(() => {
   capturedScreens.length = 0;
@@ -95,6 +104,51 @@ describe('MainTabNavigator — header right gutter', () => {
     expect(shelf).toBeDefined();
     expect(shelf?.options).not.toHaveProperty('headerRightContainerStyle');
     expect(shelf?.options).not.toHaveProperty('headerRight');
+  });
+});
+
+describe('MainTabNavigator — Timeline bookmark filter entry (headerLeft)', () => {
+  it('places the bookmark filter toggle in the Timeline headerLeft slot', () => {
+    const { render: rtlRender } = require('@testing-library/react-native');
+    render(
+      <ThemeProvider>
+        <MainTabNavigator />
+      </ThemeProvider>,
+    );
+    const timeline = capturedScreens.find((s) => s.name === 'Timeline');
+    expect(timeline).toBeDefined();
+    const headerLeft = (timeline?.options as Record<string, unknown>).headerLeft as
+      | ((props?: unknown) => React.ReactElement)
+      | undefined;
+    expect(typeof headerLeft).toBe('function');
+    const tree = rtlRender(<ThemeProvider>{headerLeft!({})}</ThemeProvider>);
+    expect(tree.getByTestId('bookmark-filter-toggle-mock')).toBeTruthy();
+    tree.unmount();
+  });
+
+  it('applies an 8pt left gutter to the Timeline screen header', () => {
+    render(
+      <ThemeProvider>
+        <MainTabNavigator />
+      </ThemeProvider>,
+    );
+    const timeline = capturedScreens.find((s) => s.name === 'Timeline');
+    expect(timeline?.options).toEqual(
+      expect.objectContaining({
+        headerLeftContainerStyle: { paddingLeft: 8 },
+      }),
+    );
+  });
+
+  it('does not place a headerLeft on the Shelf screen', () => {
+    render(
+      <ThemeProvider>
+        <MainTabNavigator />
+      </ThemeProvider>,
+    );
+    const shelf = capturedScreens.find((s) => s.name === 'Shelf');
+    expect(shelf?.options).not.toHaveProperty('headerLeft');
+    expect(shelf?.options).not.toHaveProperty('headerLeftContainerStyle');
   });
 });
 

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -9,7 +9,9 @@ import { useTheme } from '@/lib/theme';
 import { yomoyoTypography } from '@/constants/yomoyoTheme';
 import GlassTabBar from '@/components/ui/GlassTabBar';
 import AddFriendButton from '@/components/feed/AddFriendButton';
+import BookmarkFilterToggle from '@/components/feed/BookmarkFilterToggle';
 import SettingsLauncher from '@/components/settings/SettingsLauncher';
+import { BookmarkFilterProvider } from '@/lib/books/bookmarkFilterContext';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
@@ -18,6 +20,7 @@ export default function MainTabNavigator() {
   const { colors } = useTheme();
 
   return (
+    <BookmarkFilterProvider>
     <Tab.Navigator
       tabBar={(props) => <GlassTabBar {...props} />}
       screenOptions={{
@@ -39,6 +42,8 @@ export default function MainTabNavigator() {
         component={FeedScreen}
         options={{
           title: t('tabs.timeline'),
+          headerLeftContainerStyle: { paddingLeft: 8 },
+          headerLeft: () => <BookmarkFilterToggle />,
           headerRightContainerStyle: { paddingRight: 8 },
           headerRight: () => (
             <View style={styles.headerRight}>
@@ -56,6 +61,7 @@ export default function MainTabNavigator() {
         }}
       />
     </Tab.Navigator>
+    </BookmarkFilterProvider>
   );
 }
 

--- a/src/screens/FeedScreen.hooks.test.tsx
+++ b/src/screens/FeedScreen.hooks.test.tsx
@@ -1,0 +1,297 @@
+import React from 'react';
+import { Text, Pressable, View } from 'react-native';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react-native';
+import {
+  BookmarkFilterProvider,
+  useBookmarkFilter,
+} from '@/lib/books/bookmarkFilterContext';
+import { useFeedState } from './FeedScreen.hooks';
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'user1' }, loading: false }),
+}));
+
+jest.mock('@/lib/users/follows', () => ({
+  getFollowingUids: jest.fn(() => Promise.resolve(['user2'])),
+}));
+
+jest.mock('@/lib/books/friendsFeed', () => ({
+  getFriendsFeed: jest.fn(() => Promise.resolve({ items: [], lastDoc: null })),
+}));
+
+jest.mock('@/lib/books/bookmarks', () => ({
+  getBookmarkIds: jest.fn(() => Promise.resolve(new Set())),
+  getBookmarkedActivities: jest.fn(() =>
+    Promise.resolve({ items: [], lastDoc: null }),
+  ),
+  addBookmark: jest.fn(() => Promise.resolve()),
+  removeBookmark: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/lib/users/avatarIdentity', () => ({
+  ANIMAL_ASSETS: { fox: 1, bear: 2 },
+  getAvatarIdentity: jest.fn(() => Promise.resolve(null)),
+}));
+
+import { getFollowingUids } from '@/lib/users/follows';
+import { getFriendsFeed } from '@/lib/books/friendsFeed';
+import {
+  getBookmarkIds,
+  getBookmarkedActivities,
+  addBookmark,
+  removeBookmark,
+} from '@/lib/books/bookmarks';
+
+const mockGetFriendsFeed = getFriendsFeed as jest.Mock;
+const mockGetBookmarkIds = getBookmarkIds as jest.Mock;
+const mockGetBookmarkedActivities = getBookmarkedActivities as jest.Mock;
+const mockAddBookmark = addBookmark as jest.Mock;
+const mockRemoveBookmark = removeBookmark as jest.Mock;
+
+const activity = (id: string, overrides: object = {}) => ({
+  id,
+  userId: 'user2',
+  bookId: `book-${id}`,
+  title: `Title ${id}`,
+  authors: [],
+  thumbnail: null,
+  status: 'finished' as const,
+  finishedAt: null,
+  displayName: 'Bold Bear',
+  displayAvatar: 'bear',
+  ...overrides,
+});
+
+function Probe() {
+  const state = useFeedState();
+  const filter = useBookmarkFilter();
+  return (
+    <View>
+      <Text testID="items">{state.items.map((i) => i.id).join(',')}</Text>
+      <Text testID="ids">{Array.from(state.bookmarkedIds).join(',')}</Text>
+      <Text testID="loading">{String(state.isLoading)}</Text>
+      <Text testID="error">{String(state.hasError)}</Text>
+      <Pressable testID="switch-bookmarks" onPress={() => filter.setMode('bookmarks')}>
+        <Text>switch</Text>
+      </Pressable>
+      <Pressable testID="switch-all" onPress={() => filter.setMode('all')}>
+        <Text>switch-all</Text>
+      </Pressable>
+      <Pressable testID="toggle-act1" onPress={() => state.toggleBookmark('act1')}>
+        <Text>toggle</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <BookmarkFilterProvider>
+      <Probe />
+    </BookmarkFilterProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getFollowingUids as jest.Mock).mockResolvedValue(['user2']);
+  mockGetFriendsFeed.mockResolvedValue({ items: [], lastDoc: null });
+  mockGetBookmarkIds.mockResolvedValue(new Set());
+  mockGetBookmarkedActivities.mockResolvedValue({ items: [], lastDoc: null });
+});
+
+describe('useFeedState — all mode (default)', () => {
+  it('loads the friends feed and bookmark ID set on mount', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set(['act1', 'act2']));
+    renderProbe();
+    await waitFor(() => {
+      expect(mockGetFriendsFeed).toHaveBeenCalled();
+      expect(mockGetBookmarkIds).toHaveBeenCalledWith('user1');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('ids').props.children).toContain('act1');
+    });
+  });
+
+  it('does not call the bookmark-only fetcher in all mode', async () => {
+    renderProbe();
+    await waitFor(() => expect(mockGetFriendsFeed).toHaveBeenCalled());
+    expect(mockGetBookmarkedActivities).not.toHaveBeenCalled();
+  });
+});
+
+describe('useFeedState — bookmark mode switch', () => {
+  it('fetches bookmarked activities when mode flips to bookmarks', async () => {
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [activity('bm1'), activity('bm2')],
+      lastDoc: null,
+    });
+    renderProbe();
+    await waitFor(() => expect(mockGetFriendsFeed).toHaveBeenCalled());
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-bookmarks'));
+    });
+
+    await waitFor(() => {
+      expect(mockGetBookmarkedActivities).toHaveBeenCalledWith('user1', null);
+      expect(screen.getByTestId('items').props.children).toBe('bm1,bm2');
+    });
+  });
+
+  it('resets items when switching back to all mode', async () => {
+    mockGetFriendsFeed.mockResolvedValue({
+      items: [activity('a1')],
+      lastDoc: null,
+    });
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [activity('bm1')],
+      lastDoc: null,
+    });
+    renderProbe();
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('a1'),
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-bookmarks'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('bm1'),
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-all'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('a1'),
+    );
+  });
+});
+
+describe('useFeedState — toggleBookmark', () => {
+  it('adds the bookmark when activity id is not in the set', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set());
+    renderProbe();
+    await waitFor(() => expect(mockGetBookmarkIds).toHaveBeenCalled());
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-act1'));
+    });
+
+    expect(mockAddBookmark).toHaveBeenCalledWith('user1', 'act1');
+    expect(mockRemoveBookmark).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId('ids').props.children).toContain('act1');
+    });
+  });
+
+  it('removes the bookmark when activity id is in the set', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set(['act1']));
+    renderProbe();
+    await waitFor(() => {
+      expect(screen.getByTestId('ids').props.children).toContain('act1');
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-act1'));
+    });
+
+    expect(mockRemoveBookmark).toHaveBeenCalledWith('user1', 'act1');
+    expect(mockAddBookmark).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId('ids').props.children).not.toContain('act1');
+    });
+  });
+
+  it('removes the row from items immediately when in bookmarks mode', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set(['act1']));
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [activity('act1'), activity('act2')],
+      lastDoc: null,
+    });
+    renderProbe();
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-bookmarks'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('act1,act2'),
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-act1'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('act2'),
+    );
+    expect(mockRemoveBookmark).toHaveBeenCalledWith('user1', 'act1');
+  });
+
+  it('restores the row AND the bookmark id when removeBookmark fails in bookmarks mode', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set(['act1']));
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [activity('act1'), activity('act2')],
+      lastDoc: null,
+    });
+    mockRemoveBookmark.mockRejectedValueOnce(new Error('network'));
+
+    renderProbe();
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-bookmarks'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('act1,act2'),
+    );
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-act1'));
+    });
+
+    // Both the items list and the bookmark id set must roll back.
+    await waitFor(() => {
+      expect(screen.getByTestId('items').props.children).toBe('act1,act2');
+      expect(screen.getByTestId('ids').props.children).toContain('act1');
+    });
+    errSpy.mockRestore();
+  });
+});
+
+describe('useFeedState — mode-switch race protection', () => {
+  function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it('ignores a stale all-mode feed result that arrives after switching to bookmarks', async () => {
+    const slowAllFeed = deferred<{ items: ReturnType<typeof activity>[]; lastDoc: null }>();
+    mockGetFriendsFeed.mockReturnValueOnce(slowAllFeed.promise);
+
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [activity('bm1')],
+      lastDoc: null,
+    });
+
+    renderProbe();
+
+    // While the slow all-mode fetch is still pending, switch to bookmarks.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('switch-bookmarks'));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('items').props.children).toBe('bm1'),
+    );
+
+    // Late-arriving stale result from the previous mode must NOT overwrite items.
+    await act(async () => {
+      slowAllFeed.resolve({ items: [activity('a-stale')], lastDoc: null });
+    });
+
+    expect(screen.getByTestId('items').props.children).toBe('bm1');
+  });
+});

--- a/src/screens/FeedScreen.hooks.ts
+++ b/src/screens/FeedScreen.hooks.ts
@@ -3,12 +3,59 @@ import type { QueryDocumentSnapshot } from 'firebase/firestore';
 import { useAuth } from '@/hooks/useAuth';
 import { getFollowingUids } from '@/lib/users/follows';
 import { getFriendsFeed } from '@/lib/books/friendsFeed';
+import {
+  addBookmark,
+  removeBookmark,
+  getBookmarkIds,
+  getBookmarkedActivities,
+} from '@/lib/books/bookmarks';
+import { useBookmarkFilter } from '@/lib/books/bookmarkFilterContext';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
 import { getAvatarIdentity } from '@/lib/users/avatarIdentity';
 import { enrichActivityAvatars, type AvatarCache } from '@/lib/books/enrichActivityAvatars';
 
-export function useFeedState() {
+export type FeedState = {
+  items: ReadingActivity[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasError: boolean;
+  bookmarkedIds: Set<string>;
+  handleLoadMore: () => void;
+  toggleBookmark: (activityId: string) => Promise<void>;
+};
+
+type LoadResult = {
+  uids: string[];
+  ids: Set<string>;
+  items: ReadingActivity[];
+  lastDoc: QueryDocumentSnapshot | null;
+};
+
+async function loadAllFeed(uid: string): Promise<LoadResult> {
+  const [uids, ids] = await Promise.all([getFollowingUids(uid), getBookmarkIds(uid)]);
+  if (uids.length === 0) {
+    return { uids, ids, items: [], lastDoc: null };
+  }
+  const page = await getFriendsFeed(uids, null);
+  return { uids, ids, items: page.items, lastDoc: page.lastDoc };
+}
+
+async function loadBookmarkedFeed(uid: string): Promise<LoadResult> {
+  const [ids, page] = await Promise.all([
+    getBookmarkIds(uid),
+    getBookmarkedActivities(uid, null),
+  ]);
+  return { uids: [], ids, items: page.items, lastDoc: page.lastDoc };
+}
+
+function logError(prefix: string, err: unknown) {
+  const e = err as { code?: string; message?: string };
+  console.error(prefix, '— code:', e?.code, '— message:', e?.message, err);
+}
+
+export function useFeedState(): FeedState {
   const { user } = useAuth();
+  const { mode } = useBookmarkFilter();
 
   const [items, setItems] = useState<ReadingActivity[]>([]);
   const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot | null>(null);
@@ -16,57 +63,64 @@ export function useFeedState() {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
   const avatarCacheRef = useRef<AvatarCache>(new Map());
   const mountedRef = useRef(true);
 
   useEffect(() => () => { mountedRef.current = false; }, []);
 
   useEffect(() => {
-    if (!user?.uid) return;
+    const uid = user?.uid;
+    if (!uid) return;
+    let cancelled = false;
     setIsLoading(true);
     setHasError(false);
-    getFollowingUids(user.uid)
-      .then((uids) => {
-        if (!mountedRef.current) return null;
-        setFollowingUids(uids);
-        if (uids.length === 0) {
-          return { items: [] as ReadingActivity[], lastDoc: null };
-        }
-        return getFriendsFeed(uids, null);
-      })
-      .then(async (page) => {
-        if (!page || !mountedRef.current) return;
+    setItems([]);
+    setLastDoc(null);
+
+    const loader = mode === 'bookmarks' ? loadBookmarkedFeed : loadAllFeed;
+    loader(uid)
+      .then(async (result) => {
+        if (cancelled || !mountedRef.current) return;
+        setFollowingUids(result.uids);
+        setBookmarkedIds(result.ids);
         const enriched = await enrichActivityAvatars(
-          page.items,
+          result.items,
           avatarCacheRef.current,
           getAvatarIdentity,
         );
-        if (!mountedRef.current) return;
+        if (cancelled || !mountedRef.current) return;
         setItems(enriched);
-        setLastDoc(page.lastDoc);
+        setLastDoc(result.lastDoc);
       })
       .catch((err: unknown) => {
-        const e = err as { code?: string; message?: string };
-        console.error(
-          '[FeedScreen] feed load failed — code:',
-          e?.code,
-          '— message:',
-          e?.message,
-          err,
-        );
+        if (cancelled) return;
+        logError('[FeedScreen] feed load failed', err);
         if (!mountedRef.current) return;
         setHasError(true);
       })
       .finally(() => {
-        if (!mountedRef.current) return;
+        if (cancelled || !mountedRef.current) return;
         setIsLoading(false);
       });
-  }, [user?.uid]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid, mode]);
 
   const handleLoadMore = useCallback(() => {
-    if (isLoadingMore || !lastDoc || followingUids.length === 0) return;
+    if (isLoadingMore || !lastDoc) return;
+    const uid = user?.uid;
+    if (!uid) return;
     setIsLoadingMore(true);
-    getFriendsFeed(followingUids, lastDoc)
+    const fetchNext = mode === 'bookmarks'
+      ? getBookmarkedActivities(uid, lastDoc)
+      : followingUids.length === 0
+        ? Promise.resolve({ items: [], lastDoc: null })
+        : getFriendsFeed(followingUids, lastDoc);
+
+    fetchNext
       .then(async (page) => {
         if (!mountedRef.current) return;
         const enriched = await enrichActivityAvatars(
@@ -83,13 +137,59 @@ export function useFeedState() {
         if (!mountedRef.current) return;
         setIsLoadingMore(false);
       });
-  }, [isLoadingMore, lastDoc, followingUids]);
+  }, [isLoadingMore, lastDoc, followingUids, mode, user?.uid]);
+
+  const toggleBookmark = useCallback(async (activityId: string) => {
+    const uid = user?.uid;
+    if (!uid) return;
+    const wasBookmarked = bookmarkedIds.has(activityId);
+
+    // Capture the row to be removed from the current closure so rollback works
+    // even though React 18 may not run setState reducers before catch.
+    const removedAt = wasBookmarked && mode === 'bookmarks'
+      ? items.findIndex((i) => i.id === activityId)
+      : -1;
+    const removedItem = removedAt >= 0 ? items[removedAt] : undefined;
+
+    setBookmarkedIds((prev) => {
+      const next = new Set(prev);
+      if (wasBookmarked) next.delete(activityId);
+      else next.add(activityId);
+      return next;
+    });
+
+    if (removedItem) {
+      setItems((prev) => prev.filter((i) => i.id !== activityId));
+    }
+
+    try {
+      if (wasBookmarked) await removeBookmark(uid, activityId);
+      else await addBookmark(uid, activityId);
+    } catch (err) {
+      console.error('[FeedScreen] bookmark toggle failed', err);
+      if (!mountedRef.current) return;
+      setBookmarkedIds((prev) => {
+        const next = new Set(prev);
+        if (wasBookmarked) next.add(activityId);
+        else next.delete(activityId);
+        return next;
+      });
+      if (removedItem) {
+        setItems((prev) => {
+          const clampedAt = Math.min(removedAt, prev.length);
+          return [...prev.slice(0, clampedAt), removedItem, ...prev.slice(clampedAt)];
+        });
+      }
+    }
+  }, [bookmarkedIds, items, mode, user?.uid]);
 
   return {
     items,
     isLoading,
     isLoadingMore,
     hasError,
+    bookmarkedIds,
     handleLoadMore,
+    toggleBookmark,
   };
 }

--- a/src/screens/FeedScreen.test.tsx
+++ b/src/screens/FeedScreen.test.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react-native';
-import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import { ThemeProvider } from '@/lib/theme/ThemeProvider';
+import { render as rtlRender } from '@testing-library/react-native';
+import {
+  BookmarkFilterProvider,
+  type BookmarkFilterMode,
+} from '@/lib/books/bookmarkFilterContext';
 import FeedScreen from './FeedScreen';
+
+function render(
+  ui: React.ReactElement,
+  options?: { initialMode?: BookmarkFilterMode },
+) {
+  return rtlRender(
+    <ThemeProvider>
+      <BookmarkFilterProvider initialMode={options?.initialMode ?? 'all'}>
+        {ui}
+      </BookmarkFilterProvider>
+    </ThemeProvider>,
+  );
+}
 
 const mockNavigate = jest.fn();
 
@@ -29,6 +47,15 @@ jest.mock('@/lib/books/friendsFeed', () => ({
   getFriendsFeed: jest.fn(() => Promise.resolve({ items: [], lastDoc: null })),
 }));
 
+jest.mock('@/lib/books/bookmarks', () => ({
+  getBookmarkIds: jest.fn(() => Promise.resolve(new Set())),
+  getBookmarkedActivities: jest.fn(() =>
+    Promise.resolve({ items: [], lastDoc: null }),
+  ),
+  addBookmark: jest.fn(() => Promise.resolve()),
+  removeBookmark: jest.fn(() => Promise.resolve()),
+}));
+
 jest.mock('@/lib/users/avatarIdentity', () => ({
   ANIMAL_ASSETS: { fox: 1, bear: 2, seal: 3 },
   getAvatarIdentity: jest.fn(() => Promise.resolve(null)),
@@ -46,10 +73,20 @@ jest.mock('@/components/ads/TimelineBannerAd', () => {
 import { getFollowingUids } from '@/lib/users/follows';
 import { getFriendsFeed } from '@/lib/books/friendsFeed';
 import { getAvatarIdentity } from '@/lib/users/avatarIdentity';
+import {
+  getBookmarkIds,
+  getBookmarkedActivities,
+  addBookmark,
+  removeBookmark,
+} from '@/lib/books/bookmarks';
 
 const mockGetFollowingUids = getFollowingUids as jest.Mock;
 const mockGetFriendsFeed = getFriendsFeed as jest.Mock;
 const mockGetAvatarIdentity = getAvatarIdentity as jest.Mock;
+const mockGetBookmarkIds = getBookmarkIds as jest.Mock;
+const mockGetBookmarkedActivities = getBookmarkedActivities as jest.Mock;
+const mockAddBookmark = addBookmark as jest.Mock;
+const mockRemoveBookmark = removeBookmark as jest.Mock;
 
 const mockActivity = {
   id: 'act1',
@@ -90,6 +127,10 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockGetFollowingUids.mockResolvedValue(['user2']);
   mockGetFriendsFeed.mockResolvedValue({ items: [], lastDoc: null });
+  mockGetBookmarkIds.mockResolvedValue(new Set());
+  mockGetBookmarkedActivities.mockResolvedValue({ items: [], lastDoc: null });
+  mockAddBookmark.mockResolvedValue(undefined);
+  mockRemoveBookmark.mockResolvedValue(undefined);
 });
 
 describe('FeedScreen — friend updates list', () => {
@@ -378,6 +419,79 @@ describe('FeedScreen — row tap modal', () => {
     expect(mockNavigate).toHaveBeenCalledWith('UserProfile', { uid: 'user2' });
     await waitFor(() => {
       expect(screen.queryByTestId('activity-detail-modal')).toBeNull();
+    });
+  });
+});
+
+describe('FeedScreen — bookmark icon on cards', () => {
+  beforeEach(() => {
+    mockGetFriendsFeed.mockResolvedValue({ items: [mockActivity], lastDoc: null });
+  });
+
+  it('renders a bookmark toggle button on each activity card', async () => {
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Dune'));
+    expect(screen.getByTestId('bookmark-toggle-act1')).toBeTruthy();
+  });
+
+  it('shows the off (outline) state when the activity is not in the bookmark set', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set());
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByText('Dune'));
+    expect(
+      screen.getByTestId('bookmark-toggle-act1').props.accessibilityState?.selected,
+    ).toBe(false);
+  });
+
+  it('shows the on (filled) state when the activity is already bookmarked', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set(['act1']));
+    render(<FeedScreen />);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('bookmark-toggle-act1').props.accessibilityState?.selected,
+      ).toBe(true);
+    });
+  });
+
+  it('calls addBookmark when an unbookmarked icon is pressed', async () => {
+    mockGetBookmarkIds.mockResolvedValue(new Set());
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByTestId('bookmark-toggle-act1'));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('bookmark-toggle-act1'));
+    });
+    expect(mockAddBookmark).toHaveBeenCalledWith('user1', 'act1');
+  });
+
+  it('does NOT open the detail modal when the bookmark icon is pressed (tap isolation)', async () => {
+    render(<FeedScreen />);
+    await waitFor(() => screen.getByTestId('bookmark-toggle-act1'));
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('bookmark-toggle-act1'));
+    });
+    expect(screen.queryByTestId('activity-detail-modal')).toBeNull();
+  });
+});
+
+describe('FeedScreen — bookmark-only mode empty state', () => {
+  it('shows the bookmark-specific empty copy when in bookmarks mode with no items', async () => {
+    mockGetBookmarkedActivities.mockResolvedValue({ items: [], lastDoc: null });
+    render(<FeedScreen />, { initialMode: 'bookmarks' });
+    await waitFor(() => {
+      expect(screen.getByText('timeline.emptyBookmarks')).toBeTruthy();
+    });
+    expect(screen.queryByText('timeline.emptyBody')).toBeNull();
+    expect(screen.queryByTestId('add-friend-button-inline')).toBeNull();
+  });
+
+  it('renders bookmarked activities when bookmarks-mode returns items', async () => {
+    mockGetBookmarkedActivities.mockResolvedValue({
+      items: [{ ...mockActivity, id: 'bm1', title: 'Saved Book' }],
+      lastDoc: null,
+    });
+    render(<FeedScreen />, { initialMode: 'bookmarks' });
+    await waitFor(() => {
+      expect(screen.getByText('Saved Book')).toBeTruthy();
     });
   });
 });

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -13,6 +13,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import ActivityDetailModal from '@/components/feed/ActivityDetailModal';
+import ActivityBookmarkButton from '@/components/feed/ActivityBookmarkButton';
 import AddFriendButton from '@/components/feed/AddFriendButton';
 import TimelineBannerAd from '@/components/ads/TimelineBannerAd';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
@@ -21,6 +22,7 @@ import { useTheme, useThemedStyles, type ThemeColors } from '@/lib/theme';
 import { ANIMAL_ASSETS } from '@/lib/users/avatarIdentity';
 import type { AnimalKey } from '@/lib/users/avatarIdentity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
+import { useBookmarkFilter } from '@/lib/books/bookmarkFilterContext';
 import type { RootStackParamList } from '@/navigation/types';
 import { interleaveAds, type FeedRow } from '@/lib/ads/interleaveAds';
 import { TIMELINE_AD_CADENCE } from '@/constants/ads';
@@ -30,66 +32,84 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 type ActivityCardProps = {
   item: ReadingActivity;
+  bookmarked: boolean;
   onPress: (item: ReadingActivity) => void;
+  onToggleBookmark: (activityId: string) => void;
 };
 
-const ActivityCard = React.memo(function ActivityCard({ item, onPress }: ActivityCardProps) {
+const ActivityCard = React.memo(function ActivityCard({
+  item,
+  bookmarked,
+  onPress,
+  onToggleBookmark,
+}: ActivityCardProps) {
   const styles = useThemedStyles(makeStyles);
   const avatarKey = item.displayAvatar as AnimalKey | undefined;
   const avatarSource = avatarKey && ANIMAL_ASSETS[avatarKey] ? ANIMAL_ASSETS[avatarKey] : null;
   const displayName = item.displayName ?? item.displayLabel;
   const dateText = item.finishedAt ? item.finishedAt.toDate().toLocaleDateString() : null;
   return (
-    <PressableSurface
-      testID={`activity-row-${item.id}`}
-      style={styles.card}
-      onPress={() => onPress(item)}
-      accessibilityRole="button"
-      feedback="soft"
-    >
-      <View style={styles.cardHeader}>
-        {avatarSource ? (
-          <Image
-            source={avatarSource}
-            style={styles.avatar}
-            accessibilityLabel={displayName ?? undefined}
-          />
-        ) : (
-          <View
-            testID={`activity-avatar-placeholder-${item.id}`}
-            style={[styles.avatar, styles.avatarPlaceholder]}
-          />
-        )}
-        <View style={styles.cardMeta}>
-          <Text style={styles.cardUser}>{displayName ?? '—'}</Text>
-        </View>
-      </View>
-      <View style={styles.cardBody}>
-        {item.thumbnail ? (
-          <Image
-            testID={`activity-thumbnail-${item.id}`}
-            source={{ uri: item.thumbnail }}
-            style={styles.thumbnail}
-            accessibilityLabel={item.title}
-          />
-        ) : (
-          <View
-            testID={`activity-thumbnail-placeholder-${item.id}`}
-            style={[styles.thumbnail, styles.thumbnailPlaceholder]}
-          />
-        )}
-        <View testID={`activity-info-${item.id}`} style={styles.cardInfo}>
-          <Text style={styles.cardTitle} numberOfLines={2}>
-            {item.title}
-          </Text>
-          {dateText && (
-            <Text testID={`activity-date-${item.id}`} style={styles.cardDate}>
-              {dateText}
-            </Text>
+    <View style={styles.cardWrapper}>
+      <PressableSurface
+        testID={`activity-row-${item.id}`}
+        style={styles.card}
+        onPress={() => onPress(item)}
+        accessibilityRole="button"
+        feedback="soft"
+      >
+        <View style={styles.cardHeader}>
+          {avatarSource ? (
+            <Image
+              source={avatarSource}
+              style={styles.avatar}
+              accessibilityLabel={displayName ?? undefined}
+            />
+          ) : (
+            <View
+              testID={`activity-avatar-placeholder-${item.id}`}
+              style={[styles.avatar, styles.avatarPlaceholder]}
+            />
           )}
+          <View style={styles.cardMeta}>
+            <Text style={styles.cardUser}>{displayName ?? '—'}</Text>
+          </View>
         </View>
+        <View style={styles.cardBody}>
+          {item.thumbnail ? (
+            <Image
+              testID={`activity-thumbnail-${item.id}`}
+              source={{ uri: item.thumbnail }}
+              style={styles.thumbnail}
+              accessibilityLabel={item.title}
+            />
+          ) : (
+            <View
+              testID={`activity-thumbnail-placeholder-${item.id}`}
+              style={[styles.thumbnail, styles.thumbnailPlaceholder]}
+            />
+          )}
+          <View testID={`activity-info-${item.id}`} style={styles.cardInfo}>
+            <Text style={styles.cardTitle} numberOfLines={2}>
+              {item.title}
+            </Text>
+            {dateText && (
+              <Text testID={`activity-date-${item.id}`} style={styles.cardDate}>
+                {dateText}
+              </Text>
+            )}
+          </View>
+        </View>
+      </PressableSurface>
+      {/* Sibling of the row PressableSurface — tap isolation depends on this.
+          Keep cardHeader.paddingRight ≥ this button's hit area. */}
+      <View style={styles.bookmarkSlot} pointerEvents="box-none">
+        <ActivityBookmarkButton
+          activityId={item.id}
+          bookmarked={bookmarked}
+          onToggle={onToggleBookmark}
+        />
       </View>
-    </PressableSurface>
+    </View>
   );
 });
 
@@ -97,7 +117,16 @@ export default function FeedScreen() {
   const { t } = useTranslation();
   const tabBarInset = useGlassTabBarInset();
   const navigation = useNavigation<NavigationProp>();
-  const { items, isLoading, isLoadingMore, hasError, handleLoadMore } = useFeedState();
+  const {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasError,
+    bookmarkedIds,
+    handleLoadMore,
+    toggleBookmark,
+  } = useFeedState();
+  const { mode } = useBookmarkFilter();
   const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
 
@@ -119,6 +148,13 @@ export default function FeedScreen() {
     [navigation],
   );
 
+  const handleToggleBookmark = useCallback(
+    (activityId: string) => {
+      void toggleBookmark(activityId);
+    },
+    [toggleBookmark],
+  );
+
   const listData = useMemo<FeedRow<ReadingActivity>[]>(
     () => interleaveAds(items, TIMELINE_AD_CADENCE),
     [items],
@@ -133,15 +169,38 @@ export default function FeedScreen() {
           </View>
         );
       }
-      return <ActivityCard item={row.item} onPress={handleRowPress} />;
+      return (
+        <ActivityCard
+          item={row.item}
+          bookmarked={bookmarkedIds.has(row.item.id)}
+          onPress={handleRowPress}
+          onToggleBookmark={handleToggleBookmark}
+        />
+      );
     },
-    [handleRowPress, styles.adSlot],
+    [handleRowPress, handleToggleBookmark, bookmarkedIds, styles.adSlot],
   );
 
   const keyExtractor = useCallback(
     (row: FeedRow<ReadingActivity>) => (row.kind === 'ad' ? row.key : row.item.id),
     [],
   );
+
+  const renderEmpty = () => {
+    if (mode === 'bookmarks') {
+      return (
+        <View style={styles.center}>
+          <Text style={styles.emptyBody}>{t('timeline.emptyBookmarks')}</Text>
+        </View>
+      );
+    }
+    return (
+      <View style={styles.center}>
+        <Text style={styles.emptyBody}>{t('timeline.emptyBody')}</Text>
+        <AddFriendButton variant="inline" />
+      </View>
+    );
+  };
 
   return (
     <ScreenContainer bottomInset={tabBarInset}>
@@ -154,10 +213,7 @@ export default function FeedScreen() {
           <Text style={styles.emptyBody}>{t('timeline.loadErrorBody')}</Text>
         </View>
       ) : items.length === 0 ? (
-        <View style={styles.center}>
-          <Text style={styles.emptyBody}>{t('timeline.emptyBody')}</Text>
-          <AddFriendButton variant="inline" />
-        </View>
+        renderEmpty()
       ) : (
         <FlatList
           testID="updates-list"
@@ -198,21 +254,30 @@ const makeStyles = (colors: ThemeColors) =>
     list: { paddingBottom: 16 },
     loader: { marginVertical: 16 },
     adSlot: { marginBottom: 12, alignItems: 'center' },
+    cardWrapper: {
+      position: 'relative',
+      marginBottom: 12,
+    },
     card: {
       backgroundColor: colors.surface,
       borderRadius: 12,
       padding: 12,
-      marginBottom: 12,
       shadowColor: colors.text,
       shadowOffset: { width: 0, height: 1 },
       shadowOpacity: 0.06,
       shadowRadius: 4,
       elevation: 2,
     },
+    bookmarkSlot: {
+      position: 'absolute',
+      top: 4,
+      right: 4,
+    },
     cardHeader: {
       flexDirection: 'row',
       alignItems: 'center',
       marginBottom: 8,
+      paddingRight: 28,
     },
     avatar: {
       width: 32,


### PR DESCRIPTION
Users can save timeline activities with a one-tap bookmark icon on each card and switch the timeline into a bookmarked-only view via a header filter toggle. Bookmarks live under users/{uid}/bookmarks/{activityId}, scoped to the owner by Firestore rules — never visible to others.