### PR TITLE
feat: define shared spacing and typography baseline (#109)

### DIFF
--- a/src/constants/yomoyoTheme.test.ts
+++ b/src/constants/yomoyoTheme.test.ts
@@ -7,6 +7,10 @@ import {
   darkColors,
   lightGlass,
   darkGlass,
+  spacing,
+  fontSize,
+  fontWeight,
+  lineHeight,
 } from './yomoyoTheme';
 
 const COLOR_KEYS = [
@@ -190,5 +194,84 @@ describe('yomoyoSpacing', () => {
 
   it('has correct button border radius', () => {
     expect(yomoyoSpacing.buttonRadius).toBe(14);
+  });
+});
+
+describe('spacing scale (#109 shared baseline)', () => {
+  it('exposes a 4pt-based scale with documented steps', () => {
+    expect(spacing).toEqual({
+      none: 0,
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 24,
+      xxl: 32,
+      xxxl: 48,
+    });
+  });
+
+  it('every step is a non-negative multiple of 4', () => {
+    Object.values(spacing).forEach((value) => {
+      expect(value % 4).toBe(0);
+      expect(value).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it('steps increase monotonically', () => {
+    const values = Object.values(spacing);
+    const sorted = [...values].sort((a, b) => a - b);
+    expect(values).toEqual(sorted);
+  });
+});
+
+describe('typography primitive scales (#109 shared baseline)', () => {
+  it('fontSize scale exposes documented sizes', () => {
+    expect(fontSize).toEqual({
+      caption: 14,
+      body: 16,
+      bodyLg: 18,
+      title: 24,
+      display: 28,
+    });
+  });
+
+  it('fontWeight scale exposes the four brand weights', () => {
+    expect(fontWeight).toEqual({
+      regular: '400',
+      medium: '500',
+      semibold: '600',
+      bold: '700',
+    });
+  });
+
+  it('lineHeight scale exposes body line heights', () => {
+    expect(lineHeight).toEqual({ body: 24, bodyLg: 26 });
+  });
+});
+
+describe('existing tokens derive from the shared baseline (no value drift)', () => {
+  it('yomoyoSpacing.horizontalPadding uses the xxl step', () => {
+    expect(yomoyoSpacing.horizontalPadding).toBe(spacing.xxl);
+  });
+
+  it('yomoyoTypography sizes map onto the font scale', () => {
+    expect(yomoyoTypography.titleSize).toBe(fontSize.display);
+    expect(yomoyoTypography.screenTitleSize).toBe(fontSize.title);
+    expect(yomoyoTypography.bodySize).toBe(fontSize.bodyLg);
+    expect(yomoyoTypography.screenBodySize).toBe(fontSize.body);
+    expect(yomoyoTypography.errorSize).toBe(fontSize.caption);
+  });
+
+  it('yomoyoTypography line heights map onto the lineHeight scale', () => {
+    expect(yomoyoTypography.bodyLineHeight).toBe(lineHeight.bodyLg);
+    expect(yomoyoTypography.screenBodyLineHeight).toBe(lineHeight.body);
+  });
+
+  it('yomoyoTypography weights map onto the fontWeight scale', () => {
+    expect(yomoyoTypography.titleWeight).toBe(fontWeight.bold);
+    expect(yomoyoTypography.bodyWeight).toBe(fontWeight.regular);
+    expect(yomoyoTypography.buttonWeight).toBe(fontWeight.semibold);
+    expect(yomoyoTypography.secondaryActionWeight).toBe(fontWeight.medium);
   });
 });

--- a/src/constants/yomoyoTheme.ts
+++ b/src/constants/yomoyoTheme.ts
@@ -45,27 +45,66 @@ export const darkGlass = {
 export const yomoyoColors = lightColors;
 export const yomoyoGlass = lightGlass;
 
+// --- Shared baseline (#109) ---
+// A single source of truth for spacing and type so every screen can lay out
+// on the same rhythm. Semantic tokens below (yomoyoTypography / yomoyoSpacing)
+// derive from these primitives instead of repeating magic numbers.
+
+// 4pt-based spacing scale. Use these steps for padding, margins, and gaps so
+// whitespace stays consistent and "breathes" the same across screens.
+export const spacing = {
+  none: 0,
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+  xxxl: 48,
+} as const;
+
+// Type scale primitives. Semantic typography tokens map onto these sizes.
+export const fontSize = {
+  caption: 14,
+  body: 16,
+  bodyLg: 18,
+  title: 24,
+  display: 28,
+} as const;
+
+export const fontWeight = {
+  regular: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+} as const;
+
+export const lineHeight = {
+  body: 24,
+  bodyLg: 26,
+} as const;
+
 export const yomoyoTypography = {
-  titleSize: 28,
-  titleWeight: '700' as const,
-  bodySize: 18,
-  bodyLineHeight: 26,
-  bodyWeight: '400' as const,
-  buttonSize: 18,
-  buttonWeight: '600' as const,
+  titleSize: fontSize.display,
+  titleWeight: fontWeight.bold,
+  bodySize: fontSize.bodyLg,
+  bodyLineHeight: lineHeight.bodyLg,
+  bodyWeight: fontWeight.regular,
+  buttonSize: fontSize.bodyLg,
+  buttonWeight: fontWeight.semibold,
   secondaryActionSize: 17,
-  secondaryActionWeight: '500' as const,
-  subtitleSize: 18,
-  subtitleWeight: '400' as const,
-  errorSize: 14,
-  screenTitleSize: 24,
-  screenBodySize: 16,
-  screenBodyLineHeight: 24,
-  headerTitleSize: 18,
+  secondaryActionWeight: fontWeight.medium,
+  subtitleSize: fontSize.bodyLg,
+  subtitleWeight: fontWeight.regular,
+  errorSize: fontSize.caption,
+  screenTitleSize: fontSize.title,
+  screenBodySize: fontSize.body,
+  screenBodyLineHeight: lineHeight.body,
+  headerTitleSize: fontSize.bodyLg,
 } as const;
 
 export const yomoyoSpacing = {
-  horizontalPadding: 32,
+  horizontalPadding: spacing.xxl,
   buttonHeight: 56,
   buttonRadius: 14,
 } as const;


### PR DESCRIPTION
Add a 4pt-based spacing scale and typography primitive scales (fontSize/fontWeight/lineHeight) as the single source of truth. Derive existing yomoyoTypography/yomoyoSpacing tokens from them with no value drift, so #110 can apply a consistent rhythm.