### PR TITLE
refactor: unify book rows into shared BookListItem (#110)

### DIFF
--- a/src/components/books/BookListItem.test.tsx
+++ b/src/components/books/BookListItem.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import BookListItem from './BookListItem';
+
+describe('BookListItem', () => {
+  it('renders the title and joined authors', () => {
+    render(<BookListItem title="The Great Gatsby" authors={['F. Scott Fitzgerald', 'Ed.']} />);
+    expect(screen.getByText('The Great Gatsby')).toBeTruthy();
+    expect(screen.getByText('F. Scott Fitzgerald, Ed.')).toBeTruthy();
+  });
+
+  it('gives the thumbnail an accessibilityLabel matching the title', () => {
+    render(
+      <BookListItem title="Cover Book" authors={['A']} thumbnail="https://example.com/c.jpg" />,
+    );
+    expect(screen.getByLabelText('Cover Book')).toBeTruthy();
+  });
+
+  it('renders a placeholder (no image) when no thumbnail is given', () => {
+    render(<BookListItem title="No Cover" authors={['A']} />);
+    expect(screen.queryByLabelText('No Cover')).toBeNull();
+  });
+
+  it('shows the date when provided', () => {
+    render(<BookListItem title="Dated" authors={['A']} date="2026/06/21" />);
+    expect(screen.getByText('2026/06/21')).toBeTruthy();
+  });
+
+  it('omits the date when none is given', () => {
+    render(<BookListItem title="Undated" authors={['A']} />);
+    expect(screen.queryByText('2026/06/21')).toBeNull();
+  });
+
+  it('falls back to the unknown-author label when authors is empty', () => {
+    render(<BookListItem title="X" authors={[]} unknownAuthorLabel="Unknown author" />);
+    expect(screen.getByText('Unknown author')).toBeTruthy();
+  });
+
+  it('is pressable and calls onPress when an onPress handler is given', () => {
+    const onPress = jest.fn();
+    render(<BookListItem title="Tap" authors={['A']} onPress={onPress} testID="tap-item" />);
+    fireEvent.press(screen.getByTestId('tap-item'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as non-pressable (no button role) when no onPress is given', () => {
+    render(<BookListItem title="Static" authors={['A']} testID="static-item" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/src/components/books/BookListItem.tsx
+++ b/src/components/books/BookListItem.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import PressableSurface from '@/components/ui/PressableSurface';
+import { spacing, fontSize, yomoyoTypography } from '@/constants/yomoyoTheme';
+import { useThemedStyles, type ThemeColors } from '@/lib/theme';
+
+export type BookListItemProps = {
+  title: string;
+  authors: string[];
+  thumbnail?: string | null;
+  /** Pre-formatted date string. Omitted when not provided. */
+  date?: string;
+  /** When provided, the row becomes a pressable button. */
+  onPress?: () => void;
+  /** Shown instead of authors when the authors list is empty. */
+  unknownAuthorLabel?: string;
+  testID?: string;
+  accessibilityLabel?: string;
+};
+
+/**
+ * Shared book row card used across the Shelf, profile, and search screens
+ * so finished/searched books share one consistent, spacious layout (#110).
+ */
+export default function BookListItem({
+  title,
+  authors,
+  thumbnail,
+  date,
+  onPress,
+  unknownAuthorLabel,
+  testID,
+  accessibilityLabel,
+}: BookListItemProps) {
+  const styles = useThemedStyles(makeStyles);
+  const authorLabel = authors.length > 0 ? authors.join(', ') : (unknownAuthorLabel ?? '');
+
+  const content = (
+    <>
+      {thumbnail ? (
+        <Image
+          source={{ uri: thumbnail }}
+          style={styles.thumbnail}
+          accessibilityLabel={title}
+        />
+      ) : (
+        <View style={[styles.thumbnail, styles.thumbnailPlaceholder]} />
+      )}
+      <View style={styles.info}>
+        <Text style={styles.title}>{title}</Text>
+        {authorLabel ? <Text style={styles.author}>{authorLabel}</Text> : null}
+        {date ? <Text style={styles.date}>{date}</Text> : null}
+      </View>
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <PressableSurface
+        style={styles.card}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        testID={testID}
+        feedback="soft"
+      >
+        {content}
+      </PressableSurface>
+    );
+  }
+
+  return (
+    <View style={styles.card} testID={testID}>
+      {content}
+    </View>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    card: {
+      flexDirection: 'row',
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: spacing.md,
+      marginBottom: spacing.md,
+      shadowColor: colors.text,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.06,
+      shadowRadius: 4,
+      elevation: 2,
+    },
+    thumbnail: {
+      width: 52,
+      height: 72,
+      borderRadius: 6,
+      marginRight: spacing.md,
+    },
+    thumbnailPlaceholder: {
+      backgroundColor: colors.border,
+    },
+    info: {
+      flex: 1,
+      justifyContent: 'center',
+    },
+    title: {
+      fontSize: yomoyoTypography.screenBodySize,
+      fontWeight: yomoyoTypography.buttonWeight,
+      color: colors.text,
+      marginBottom: spacing.xs,
+    },
+    author: {
+      fontSize: fontSize.caption,
+      color: colors.secondaryText,
+    },
+    date: {
+      fontSize: 13,
+      color: colors.muted,
+      marginTop: spacing.xs,
+    },
+  });

--- a/src/screens/BookSearchScreen.tsx
+++ b/src/screens/BookSearchScreen.tsx
@@ -4,18 +4,18 @@ import {
   Text,
   TextInput,
   FlatList,
-  Image,
   StyleSheet,
   ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import PressableSurface from '@/components/ui/PressableSurface';
+import BookListItem from '@/components/books/BookListItem';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { searchBooks, type Book } from '@/lib/books/searchBooks';
 import type { RootStackParamList } from '@/navigation/types';
-import { yomoyoTypography } from '@/constants/yomoyoTheme';
+import { yomoyoTypography, spacing } from '@/constants/yomoyoTheme';
 import { useThemedStyles, useTheme, type ThemeColors } from '@/lib/theme';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -106,25 +106,15 @@ export default function BookSearchScreen() {
       <FlatList
         data={results ?? []}
         keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
         renderItem={({ item }) => (
-          <PressableSurface
-            style={styles.resultItem}
+          <BookListItem
+            title={item.title}
+            authors={item.authors}
+            thumbnail={item.thumbnail}
             onPress={() => handleSelect(item)}
-            accessibilityRole="button"
-            feedback="soft"
-          >
-            {item.thumbnail ? (
-              <Image source={{ uri: item.thumbnail }} style={styles.thumbnail} />
-            ) : (
-              <View style={styles.thumbnailPlaceholder} />
-            )}
-            <View style={styles.bookInfo}>
-              <Text style={styles.bookTitle}>{item.title}</Text>
-              <Text style={styles.bookAuthor}>
-                {item.authors.length > 0 ? item.authors.join(', ') : t('bookSearch.unknownAuthor')}
-              </Text>
-            </View>
-          </PressableSurface>
+            unknownAuthorLabel={t('bookSearch.unknownAuthor')}
+          />
         )}
       />
     </View>
@@ -134,26 +124,26 @@ export default function BookSearchScreen() {
 const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
     container: { flex: 1, backgroundColor: colors.background },
-    searchRow: { flexDirection: 'row', padding: 16, gap: 8 },
+    searchRow: { flexDirection: 'row', padding: spacing.lg, gap: spacing.sm },
     input: {
       flex: 1,
       borderWidth: 1,
       borderColor: colors.border,
       borderRadius: 8,
-      paddingHorizontal: 12,
+      paddingHorizontal: spacing.md,
       paddingVertical: 10,
       fontSize: yomoyoTypography.screenBodySize,
     },
     button: {
       backgroundColor: colors.primary,
       borderRadius: 8,
-      paddingHorizontal: 16,
+      paddingHorizontal: spacing.lg,
       justifyContent: 'center',
     },
     scanButton: {
       backgroundColor: colors.primary,
       borderRadius: 8,
-      paddingHorizontal: 12,
+      paddingHorizontal: spacing.md,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -165,7 +155,7 @@ const makeStyles = (colors: ThemeColors) =>
       fontSize: yomoyoTypography.screenBodySize,
       fontWeight: yomoyoTypography.buttonWeight,
     },
-    loading: { marginTop: 24 },
+    loading: { marginTop: spacing.xl },
     errorText: {
       textAlign: 'center',
       marginTop: 40,
@@ -178,20 +168,8 @@ const makeStyles = (colors: ThemeColors) =>
       color: colors.muted,
       fontSize: yomoyoTypography.screenBodySize,
     },
-    resultItem: {
-      flexDirection: 'row',
-      padding: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: colors.border,
+    listContent: {
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.sm,
     },
-    thumbnail: { width: 50, height: 72, borderRadius: 4, backgroundColor: colors.border },
-    thumbnailPlaceholder: { width: 50, height: 72, borderRadius: 4, backgroundColor: colors.border },
-    bookInfo: { flex: 1, marginLeft: 12, justifyContent: 'center' },
-    bookTitle: {
-      fontSize: 15,
-      fontWeight: yomoyoTypography.buttonWeight,
-      marginBottom: 4,
-      color: colors.text,
-    },
-    bookAuthor: { fontSize: 13, color: colors.secondaryText },
   });

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { View, Text, ScrollView, Image, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import PressableSurface from '@/components/ui/PressableSurface';
 import { useNavigation } from '@react-navigation/native';
@@ -7,7 +7,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import ScreenContainer from '@/components/layout/ScreenContainer';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
-import { yomoyoTypography } from '@/constants/yomoyoTheme';
+import { yomoyoTypography, spacing } from '@/constants/yomoyoTheme';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/lib/theme';
 import { useAuth } from '@/hooks/useAuth';
 import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
@@ -17,6 +17,7 @@ import ReadingHistoryHeatmap from '@/components/profile/ReadingHistoryHeatmap';
 import type { RootStackParamList } from '@/navigation/types';
 import MyHandleCard from '@/components/shelf/MyHandleCard';
 import MyIdentityHeader from '@/components/shelf/MyIdentityHeader';
+import BookListItem from '@/components/books/BookListItem';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -74,24 +75,13 @@ export default function ShelfScreen() {
           <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
         ) : (
           activities.map((item) => (
-            <View key={item.id} style={styles.card}>
-              {item.thumbnail ? (
-                <Image
-                  source={{ uri: item.thumbnail }}
-                  style={styles.thumbnail}
-                  accessibilityLabel={item.title}
-                />
-              ) : (
-                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]} />
-              )}
-              <View style={styles.cardInfo}>
-                <Text style={styles.bookTitle}>{item.title}</Text>
-                <Text style={styles.author}>{item.authors.join(', ')}</Text>
-                {item.finishedAt && (
-                  <Text style={styles.date}>{item.finishedAt.toDate().toLocaleDateString()}</Text>
-                )}
-              </View>
-            </View>
+            <BookListItem
+              key={item.id}
+              title={item.title}
+              authors={item.authors}
+              thumbnail={item.thumbnail}
+              date={item.finishedAt ? item.finishedAt.toDate().toLocaleDateString() : undefined}
+            />
           ))
         )}
       </ScrollView>
@@ -113,18 +103,18 @@ export default function ShelfScreen() {
 const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
     fixedHeader: {
-      paddingTop: 16,
+      paddingTop: spacing.lg,
     },
     scroll: {
       flex: 1,
     },
     content: {
-      paddingBottom: 16,
+      paddingBottom: spacing.lg,
     },
     statsBlock: {
       alignItems: 'center',
-      marginTop: 8,
-      marginBottom: 16,
+      marginTop: spacing.sm,
+      marginBottom: spacing.lg,
     },
     countLine: {
       fontSize: 14,
@@ -135,52 +125,12 @@ const makeStyles = (colors: ThemeColors) =>
       fontSize: yomoyoTypography.screenTitleSize,
       fontWeight: yomoyoTypography.titleWeight,
       color: colors.text,
-      marginBottom: 12,
+      marginBottom: spacing.md,
     },
     emptyText: {
       fontSize: yomoyoTypography.screenBodySize,
       color: colors.muted,
-      marginBottom: 8,
-    },
-    card: {
-      flexDirection: 'row',
-      backgroundColor: colors.surface,
-      borderRadius: 12,
-      padding: 12,
-      marginBottom: 12,
-      shadowColor: colors.text,
-      shadowOffset: { width: 0, height: 1 },
-      shadowOpacity: 0.06,
-      shadowRadius: 4,
-      elevation: 2,
-    },
-    thumbnail: {
-      width: 52,
-      height: 72,
-      borderRadius: 6,
-      marginRight: 12,
-    },
-    thumbnailPlaceholder: {
-      backgroundColor: colors.border,
-    },
-    cardInfo: {
-      flex: 1,
-      justifyContent: 'center',
-    },
-    bookTitle: {
-      fontSize: yomoyoTypography.screenBodySize,
-      fontWeight: yomoyoTypography.buttonWeight,
-      color: colors.text,
-      marginBottom: 4,
-    },
-    author: {
-      fontSize: 14,
-      color: colors.secondaryText,
-      marginBottom: 4,
-    },
-    date: {
-      fontSize: 13,
-      color: colors.muted,
+      marginBottom: spacing.sm,
     },
     cta: {
       flexDirection: 'row',
@@ -190,7 +140,7 @@ const makeStyles = (colors: ThemeColors) =>
       borderRadius: 14,
       paddingVertical: 14,
       paddingHorizontal: 20,
-      gap: 8,
+      gap: spacing.sm,
     },
     ctaText: {
       color: colors.surface,

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -14,9 +14,10 @@ import { subscribeToReadingActivities } from '@/lib/books/readingActivity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
 import { bucketActivitiesByWeek, HISTORY_WINDOW_WEEKS } from '@/lib/books/readingHistory';
 import ReadingHistoryHeatmap from '@/components/profile/ReadingHistoryHeatmap';
+import BookListItem from '@/components/books/BookListItem';
 import { isFollowing, followUser, unfollowUser } from '@/lib/users/follows';
 import type { RootStackParamList } from '@/navigation/types';
-import { yomoyoTypography } from '@/constants/yomoyoTheme';
+import { yomoyoTypography, spacing } from '@/constants/yomoyoTheme';
 import { useThemedStyles, type ThemeColors } from '@/lib/theme';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -165,21 +166,12 @@ export default function UserProfileScreen() {
           <Text style={styles.emptyText}>{t('userProfile.emptyBooks')}</Text>
         ) : (
           activities.map((item) => (
-            <View key={item.id} style={styles.card}>
-              {item.thumbnail ? (
-                <Image
-                  source={{ uri: item.thumbnail }}
-                  style={styles.thumbnail}
-                  accessibilityLabel={item.title}
-                />
-              ) : (
-                <View style={[styles.thumbnail, styles.thumbnailPlaceholder]} />
-              )}
-              <View style={styles.cardInfo}>
-                <Text style={styles.bookTitle}>{item.title}</Text>
-                <Text style={styles.author}>{item.authors.join(', ')}</Text>
-              </View>
-            </View>
+            <BookListItem
+              key={item.id}
+              title={item.title}
+              authors={item.authors}
+              thumbnail={item.thumbnail}
+            />
           ))
         )}
       </ScrollView>
@@ -190,9 +182,9 @@ export default function UserProfileScreen() {
 const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
     navButton: {
-      paddingHorizontal: 16,
-      paddingBottom: 8,
-      marginLeft: 8,
+      paddingHorizontal: spacing.lg,
+      paddingBottom: spacing.sm,
+      marginLeft: spacing.sm,
       alignSelf: 'flex-start',
     },
     navButtonText: {
@@ -201,23 +193,23 @@ const makeStyles = (colors: ThemeColors) =>
     },
     ownProfileBlock: {
       alignItems: 'center',
-      marginBottom: 32,
+      marginBottom: spacing.xxl,
     },
     ownPageNote: {
       fontSize: yomoyoTypography.screenBodySize,
       color: colors.secondaryText,
-      marginBottom: 16,
+      marginBottom: spacing.lg,
     },
     ownActionsRow: {
       flexDirection: 'row',
-      gap: 12,
+      gap: spacing.md,
     },
     shelfButton: {
       borderRadius: 20,
       borderWidth: 1,
       borderColor: colors.border,
       paddingVertical: 10,
-      paddingHorizontal: 24,
+      paddingHorizontal: spacing.xl,
     },
     shelfButtonText: {
       fontSize: yomoyoTypography.screenBodySize,
@@ -225,16 +217,16 @@ const makeStyles = (colors: ThemeColors) =>
       color: colors.text,
     },
     content: {
-      paddingTop: 16,
-      paddingBottom: 24,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.xl,
     },
     identityBlock: {
       alignItems: 'center',
-      marginBottom: 16,
+      marginBottom: spacing.lg,
     },
     statsBlock: {
       alignItems: 'center',
-      marginBottom: 24,
+      marginBottom: spacing.xl,
     },
     countLine: {
       fontSize: 14,
@@ -245,7 +237,7 @@ const makeStyles = (colors: ThemeColors) =>
       width: 72,
       height: 72,
       borderRadius: 36,
-      marginBottom: 12,
+      marginBottom: spacing.md,
     },
     displayName: {
       fontSize: yomoyoTypography.screenTitleSize,
@@ -259,7 +251,7 @@ const makeStyles = (colors: ThemeColors) =>
       borderColor: colors.primary,
       paddingVertical: 10,
       paddingHorizontal: 28,
-      marginBottom: 32,
+      marginBottom: spacing.xxl,
     },
     followButtonActive: {
       backgroundColor: colors.primary,
@@ -276,7 +268,7 @@ const makeStyles = (colors: ThemeColors) =>
       fontSize: 14,
       fontWeight: '600',
       color: colors.secondaryText,
-      marginBottom: 12,
+      marginBottom: spacing.md,
       textTransform: 'uppercase',
       letterSpacing: 0.5,
     },
@@ -284,45 +276,10 @@ const makeStyles = (colors: ThemeColors) =>
       fontSize: yomoyoTypography.screenBodySize,
       color: colors.muted,
     },
-    card: {
-      flexDirection: 'row',
-      backgroundColor: colors.surface,
-      borderRadius: 12,
-      padding: 12,
-      marginBottom: 12,
-      shadowColor: colors.text,
-      shadowOffset: { width: 0, height: 1 },
-      shadowOpacity: 0.06,
-      shadowRadius: 4,
-      elevation: 2,
-    },
-    thumbnail: {
-      width: 52,
-      height: 72,
-      borderRadius: 6,
-      marginRight: 12,
-    },
-    thumbnailPlaceholder: {
-      backgroundColor: colors.border,
-    },
-    cardInfo: {
-      flex: 1,
-      justifyContent: 'center',
-    },
-    bookTitle: {
-      fontSize: yomoyoTypography.screenBodySize,
-      fontWeight: yomoyoTypography.buttonWeight,
-      color: colors.text,
-      marginBottom: 4,
-    },
-    author: {
-      fontSize: 14,
-      color: colors.secondaryText,
-    },
     notFound: {
       fontSize: yomoyoTypography.screenBodySize,
       color: colors.muted,
       textAlign: 'center',
-      marginTop: 48,
+      marginTop: spacing.xxxl,
     },
   });


### PR DESCRIPTION
Extract a shared BookListItem card used by Shelf, UserProfile, and BookSearch, removing three near-identical card implementations. Apply the #109 spacing scale to the touched screens for a consistent, more spacious rhythm. Search results now use the same card style.