### PR TITLE
feat: add EmptyState with a clear next action for empty feeds (#112)

### DIFF
--- a/src/components/ui/EmptyState.test.tsx
+++ b/src/components/ui/EmptyState.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { screen } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import EmptyState from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the message', () => {
+    render(<EmptyState message="Nothing here yet" />);
+    expect(screen.getByText('Nothing here yet')).toBeTruthy();
+  });
+
+  it('renders a title when one is provided', () => {
+    render(<EmptyState title="No books" message="Add your first book" />);
+    expect(screen.getByText('No books')).toBeTruthy();
+  });
+
+  it('omits the title when none is provided', () => {
+    render(<EmptyState message="only a message" />);
+    expect(screen.queryByText('No books')).toBeNull();
+  });
+
+  it('renders the action node when provided', () => {
+    render(<EmptyState message="m" action={<Text>Do the next thing</Text>} />);
+    expect(screen.getByText('Do the next thing')).toBeTruthy();
+  });
+
+  it('omits the action area when no action is given', () => {
+    render(<EmptyState message="m" testID="empty" />);
+    expect(screen.queryByText('Do the next thing')).toBeNull();
+  });
+
+  it('exposes the testID on the container', () => {
+    render(<EmptyState message="m" testID="empty-state" />);
+    expect(screen.getByTestId('empty-state')).toBeTruthy();
+  });
+});

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { spacing, yomoyoTypography } from '@/constants/yomoyoTheme';
+import { useTheme, useThemedStyles, type ThemeColors } from '@/lib/theme';
+
+const ICON_SIZE = 48;
+
+export type EmptyStateProps = {
+  /** The guiding sentence shown to the user. */
+  message: string;
+  /** Optional bold headline above the message. */
+  title?: string;
+  /** Optional Ionicons glyph shown above the title. */
+  icon?: keyof typeof Ionicons.glyphMap;
+  /** The "next action" — typically a CTA button. Rendered below the message. */
+  action?: React.ReactNode;
+  testID?: string;
+};
+
+/**
+ * Centered empty-state block that always points the user to a next action
+ * (#112). Used for empty feeds, shelves, and first-run screens so a blank
+ * state never leaves the user wondering what to do next.
+ */
+export default function EmptyState({ message, title, icon, action, testID }: EmptyStateProps) {
+  const styles = useThemedStyles(makeStyles);
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container} testID={testID}>
+      {icon ? (
+        <Ionicons name={icon} size={ICON_SIZE} color={colors.muted} style={styles.icon} />
+      ) : null}
+      {title ? <Text style={styles.title}>{title}</Text> : null}
+      <Text style={styles.message}>{message}</Text>
+      {action ? <View style={styles.action}>{action}</View> : null}
+    </View>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: spacing.xxl,
+    },
+    icon: {
+      marginBottom: spacing.md,
+    },
+    title: {
+      fontSize: yomoyoTypography.screenTitleSize,
+      fontWeight: yomoyoTypography.titleWeight,
+      color: colors.text,
+      textAlign: 'center',
+      marginBottom: spacing.sm,
+    },
+    message: {
+      fontSize: yomoyoTypography.screenBodySize,
+      lineHeight: yomoyoTypography.screenBodyLineHeight,
+      color: colors.secondaryText,
+      textAlign: 'center',
+    },
+    action: {
+      marginTop: spacing.lg,
+    },
+  });

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -8,8 +8,11 @@ const en = {
   },
   timeline: {
     finishedReading: 'Finished reading',
+    emptyTitle: 'Connect with friends',
     emptyBody: 'Reading records from your friends will appear here.',
+    emptyBookmarksTitle: 'No bookmarks yet',
     emptyBookmarks: 'No bookmarks yet. Tap the bookmark icon on a card to save it.',
+    loadErrorTitle: "Couldn't load",
     loadErrorBody: 'Something went wrong. Please try again.',
     modalViewProfile: 'View profile',
     modalClose: 'Close',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -8,8 +8,11 @@ const ja = {
   },
   timeline: {
     finishedReading: '読み終えました',
+    emptyTitle: '友達とつながろう',
     emptyBody: '友達の読了した記録が表示されます。',
+    emptyBookmarksTitle: 'ブックマークはまだありません',
     emptyBookmarks: 'ブックマークはまだありません。気になる本のしおりアイコンを押して保存できます。',
+    loadErrorTitle: '読み込めませんでした',
     loadErrorBody: '読み込みに失敗しました。もう一度お試しください。',
     modalViewProfile: 'プロフィールを見る',
     modalClose: '閉じる',

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -15,6 +15,7 @@ import ScreenContainer from '@/components/layout/ScreenContainer';
 import ActivityDetailModal from '@/components/feed/ActivityDetailModal';
 import ActivityBookmarkButton from '@/components/feed/ActivityBookmarkButton';
 import AddFriendButton from '@/components/feed/AddFriendButton';
+import EmptyState from '@/components/ui/EmptyState';
 import TimelineBannerAd from '@/components/ads/TimelineBannerAd';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
 import { yomoyoTypography } from '@/constants/yomoyoTheme';
@@ -189,16 +190,20 @@ export default function FeedScreen() {
   const renderEmpty = () => {
     if (mode === 'bookmarks') {
       return (
-        <View style={styles.center}>
-          <Text style={styles.emptyBody}>{t('timeline.emptyBookmarks')}</Text>
-        </View>
+        <EmptyState
+          icon="bookmark-outline"
+          title={t('timeline.emptyBookmarksTitle')}
+          message={t('timeline.emptyBookmarks')}
+        />
       );
     }
     return (
-      <View style={styles.center}>
-        <Text style={styles.emptyBody}>{t('timeline.emptyBody')}</Text>
-        <AddFriendButton variant="inline" />
-      </View>
+      <EmptyState
+        icon="people-outline"
+        title={t('timeline.emptyTitle')}
+        message={t('timeline.emptyBody')}
+        action={<AddFriendButton variant="inline" />}
+      />
     );
   };
 
@@ -209,9 +214,11 @@ export default function FeedScreen() {
           <ActivityIndicator color={colors.primary} />
         </View>
       ) : hasError ? (
-        <View style={styles.center}>
-          <Text style={styles.emptyBody}>{t('timeline.loadErrorBody')}</Text>
-        </View>
+        <EmptyState
+          icon="cloud-offline-outline"
+          title={t('timeline.loadErrorTitle')}
+          message={t('timeline.loadErrorBody')}
+        />
       ) : items.length === 0 ? (
         renderEmpty()
       ) : (
@@ -244,12 +251,6 @@ const makeStyles = (colors: ThemeColors) =>
       alignItems: 'center',
       justifyContent: 'center',
       paddingHorizontal: 32,
-    },
-    emptyBody: {
-      fontSize: yomoyoTypography.screenBodySize,
-      lineHeight: yomoyoTypography.screenBodyLineHeight,
-      color: colors.secondaryText,
-      textAlign: 'center',
     },
     list: { paddingBottom: 16 },
     loader: { marginVertical: 16 },


### PR DESCRIPTION
Introduce a reusable EmptyState (icon + title + message + action) so a blank screen always tells the user what to do next. Apply it to the Timeline empty, bookmark-empty, and load-error states, keeping the inline Add Friend call to action as the next step on an empty feed.