### PR TITLE
feat: add view-in-shelf next action after finishing a book (#106)

### DIFF
--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -51,6 +51,7 @@ const en = {
   },
   bookDetail: {
     unknownAuthor: 'Unknown author',
+    goToShelf: 'View in shelf',
   },
   shelf: {
     finished: 'Finished',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -51,6 +51,7 @@ const ja = {
   },
   bookDetail: {
     unknownAuthor: '著者不明',
+    goToShelf: '本棚で見る',
   },
   shelf: {
     finished: '読み終えた本',

--- a/src/screens/BookDetailScreen.test.tsx
+++ b/src/screens/BookDetailScreen.test.tsx
@@ -11,9 +11,12 @@ const mockBook = {
   thumbnail: 'https://example.com/cover.jpg',
 };
 
+const mockNavigate = jest.fn();
+
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useRoute: jest.fn(),
+  useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -61,6 +64,28 @@ describe('BookDetailScreen', () => {
     });
     mockMarkAsFinished.mockClear();
     mockGetAvatarIdentity.mockClear();
+    mockNavigate.mockClear();
+  });
+
+  it('does not show the view-in-shelf next action before finishing', () => {
+    render(<BookDetailScreen />);
+    expect(screen.queryByText('bookDetail.goToShelf')).toBeNull();
+  });
+
+  it('shows a view-in-shelf next action after finishing', async () => {
+    render(<BookDetailScreen />);
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
+    await waitFor(() => {
+      expect(screen.getByText('bookDetail.goToShelf')).toBeTruthy();
+    });
+  });
+
+  it('navigates to the Shelf tab when the next action is pressed', async () => {
+    render(<BookDetailScreen />);
+    fireEvent.press(screen.getByText('shelf.markAsFinished'));
+    await waitFor(() => screen.getByText('bookDetail.goToShelf'));
+    fireEvent.press(screen.getByText('bookDetail.goToShelf'));
+    expect(mockNavigate).toHaveBeenCalledWith('MainTabs', { screen: 'Shelf' });
   });
 
   it('renders the book title', () => {
@@ -132,7 +157,10 @@ describe('BookDetailScreen', () => {
     await waitFor(() => {
       expect(screen.getByText('shelf.finished')).toBeTruthy();
     });
-    expect(screen.getByRole('button').props.accessibilityState?.disabled).toBe(true);
+    // The finished button is the first button; a second "view in shelf"
+    // next-action button is also present after finishing.
+    const [finishedButton] = screen.getAllByRole('button');
+    expect(finishedButton.props.accessibilityState?.disabled).toBe(true);
   });
 
   it('returns to Mark as Finished label so the user can retry on failure', async () => {

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -6,8 +6,9 @@ import {
   ScrollView,
 } from 'react-native';
 import PressableSurface from '@/components/ui/PressableSurface';
-import { useRoute } from '@react-navigation/native';
+import { useRoute, useNavigation } from '@react-navigation/native';
 import type { RouteProp } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import type { RootStackParamList } from '@/navigation/types';
 import { yomoyoTypography } from '@/constants/yomoyoTheme';
@@ -18,10 +19,12 @@ import type { Presenter } from '@/lib/books/readingActivity';
 import { getAvatarIdentity } from '@/lib/users/avatarIdentity';
 
 type RouteType = RouteProp<RootStackParamList, 'BookDetail'>;
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 export default function BookDetailScreen() {
   const { t } = useTranslation();
   const route = useRoute<RouteType>();
+  const navigation = useNavigation<NavigationProp>();
   const { book } = route.params;
   const { user } = useAuth();
   const styles = useThemedStyles(makeStyles);
@@ -69,6 +72,16 @@ export default function BookDetailScreen() {
           {hasFinished ? t('shelf.finished') : t('shelf.markAsFinished')}
         </Text>
       </PressableSurface>
+      {hasFinished ? (
+        <PressableSurface
+          style={styles.nextActionButton}
+          onPress={() => navigation.navigate('MainTabs', { screen: 'Shelf' })}
+          accessibilityRole="button"
+          feedback="standard"
+        >
+          <Text style={styles.nextActionText}>{t('bookDetail.goToShelf')}</Text>
+        </PressableSurface>
+      ) : null}
     </ScrollView>
   );
 }
@@ -113,6 +126,21 @@ const makeStyles = (colors: ThemeColors) =>
     buttonDone: { backgroundColor: colors.muted },
     buttonText: {
       color: colors.surface,
+      fontSize: yomoyoTypography.screenBodySize,
+      fontWeight: yomoyoTypography.buttonWeight,
+    },
+    nextActionButton: {
+      height: 52,
+      borderRadius: 14,
+      paddingHorizontal: 32,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: colors.primary,
+      marginTop: 12,
+    },
+    nextActionText: {
+      color: colors.primary,
       fontSize: yomoyoTypography.screenBodySize,
       fontWeight: yomoyoTypography.buttonWeight,
     },


### PR DESCRIPTION
Resolve the BookDetail dead-end identified in the #111 flow analysis: after marking a book finished, surface a 'view in shelf' call to action that navigates to the Shelf tab, so the record flow has a clear next step instead of stopping on a disabled button.