### PR TITLE
feat: make the bookmark filter visible with a label and pill (#106)

### DIFF
--- a/src/components/feed/BookmarkFilterToggle.test.tsx
+++ b/src/components/feed/BookmarkFilterToggle.test.tsx
@@ -33,6 +33,29 @@ describe('BookmarkFilterToggle', () => {
     );
   });
 
+  it('shows a visible bookmark label so the filter is self-explanatory', () => {
+    renderWithProvider(<BookmarkFilterToggle />);
+    expect(screen.getByText('timeline.filterLabel')).toBeTruthy();
+  });
+
+  it('applies an active pill background only when bookmarks-only is selected', () => {
+    const flatten = (style: unknown) =>
+      Object.assign({}, ...(Array.isArray(style) ? style : [style]).filter(Boolean));
+    renderWithProvider(
+      <>
+        <ModeProbe />
+        <BookmarkFilterToggle />
+      </>,
+    );
+    const before = flatten(screen.getByTestId('bookmark-filter-toggle').props.style);
+    expect(before.backgroundColor).toBeUndefined();
+    act(() => {
+      fireEvent.press(screen.getByTestId('bookmark-filter-toggle'));
+    });
+    const after = flatten(screen.getByTestId('bookmark-filter-toggle').props.style);
+    expect(after.backgroundColor).toBeDefined();
+  });
+
   it('flips the filter mode when pressed', () => {
     renderWithProvider(
       <>

--- a/src/components/feed/BookmarkFilterToggle.tsx
+++ b/src/components/feed/BookmarkFilterToggle.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import PressableSurface from '@/components/ui/PressableSurface';
 import { useTheme } from '@/lib/theme';
 import { useBookmarkFilter } from '@/lib/books/bookmarkFilterContext';
+
+const ICON_SIZE = 18;
 
 export default function BookmarkFilterToggle() {
   const { t } = useTranslation();
@@ -12,6 +14,7 @@ export default function BookmarkFilterToggle() {
   const { mode, toggle } = useBookmarkFilter();
   const isBookmarksOnly = mode === 'bookmarks';
   const label = isBookmarksOnly ? t('timeline.filterAll') : t('timeline.filterBookmarks');
+  const accent = isBookmarksOnly ? colors.primary : colors.secondaryText;
 
   return (
     <PressableSurface
@@ -20,22 +23,31 @@ export default function BookmarkFilterToggle() {
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ selected: isBookmarksOnly }}
-      style={styles.button}
+      style={[styles.button, isBookmarksOnly && { backgroundColor: colors.selectedBackground }]}
       hitSlop={8}
       feedback="standard"
     >
       <Ionicons
         name={isBookmarksOnly ? 'bookmark' : 'bookmark-outline'}
-        size={22}
-        color={isBookmarksOnly ? colors.primary : colors.text}
+        size={ICON_SIZE}
+        color={accent}
       />
+      <Text style={[styles.label, { color: accent }]}>{t('timeline.filterLabel')}</Text>
     </PressableSurface>
   );
 }
 
 const styles = StyleSheet.create({
   button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -18,6 +18,7 @@ const en = {
     modalClose: 'Close',
     bookmarkAdd: 'Save bookmark',
     bookmarkRemove: 'Remove bookmark',
+    filterLabel: 'Bookmarks',
     filterBookmarks: 'Show bookmarks only',
     filterAll: 'Show all',
   },

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -18,6 +18,7 @@ const ja = {
     modalClose: '閉じる',
     bookmarkAdd: 'ブックマークに追加',
     bookmarkRemove: 'ブックマークを外す',
+    filterLabel: 'ブックマーク',
     filterBookmarks: 'ブックマークのみ表示',
     filterAll: 'すべて表示',
   },


### PR DESCRIPTION
Address B-1 from the #111 flow analysis: the bookmark filter was an icon-only toggle whose meaning and on/off state were unclear. Add a 'Bookmarks' label beside the icon and an active pill background so the filter explains itself and its current state at a glance.