### PR TITLE
feat: guide users to record their first book on an empty shelf (#106)

### DIFF
--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -55,6 +55,7 @@ const en = {
   },
   shelf: {
     finished: 'Finished',
+    emptyTitle: 'Record your first book',
     emptyFinished: 'No finished books yet',
     addBook: 'Add a finished book',
     markAsFinished: 'Mark as Finished',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -55,6 +55,7 @@ const ja = {
   },
   shelf: {
     finished: '読み終えた本',
+    emptyTitle: '最初の1冊を記録しよう',
     emptyFinished: '読み終えた本はまだありません',
     addBook: '本を追加',
     markAsFinished: '読んだ！',

--- a/src/screens/ShelfScreen.test.tsx
+++ b/src/screens/ShelfScreen.test.tsx
@@ -80,6 +80,11 @@ describe('ShelfScreen', () => {
     expect(screen.getByText('shelf.emptyFinished')).toBeTruthy();
   });
 
+  it('guides the user to record their first book in the empty state', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByText('shelf.emptyTitle')).toBeTruthy();
+  });
+
   it('subscribes to activities for the current user on mount', () => {
     render(<ShelfScreen />);
     expect(mockSubscribe).toHaveBeenCalledWith('user1', expect.any(Function));

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -18,6 +18,7 @@ import type { RootStackParamList } from '@/navigation/types';
 import MyHandleCard from '@/components/shelf/MyHandleCard';
 import MyIdentityHeader from '@/components/shelf/MyIdentityHeader';
 import BookListItem from '@/components/books/BookListItem';
+import EmptyState from '@/components/ui/EmptyState';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
@@ -72,7 +73,11 @@ export default function ShelfScreen() {
         showsVerticalScrollIndicator={false}
       >
         {activities.length === 0 ? (
-          <Text style={styles.emptyText}>{t('shelf.emptyFinished')}</Text>
+          <EmptyState
+            icon="book-outline"
+            title={t('shelf.emptyTitle')}
+            message={t('shelf.emptyFinished')}
+          />
         ) : (
           activities.map((item) => (
             <BookListItem
@@ -109,6 +114,7 @@ const makeStyles = (colors: ThemeColors) =>
       flex: 1,
     },
     content: {
+      flexGrow: 1,
       paddingBottom: spacing.lg,
     },
     statsBlock: {
@@ -126,11 +132,6 @@ const makeStyles = (colors: ThemeColors) =>
       fontWeight: yomoyoTypography.titleWeight,
       color: colors.text,
       marginBottom: spacing.md,
-    },
-    emptyText: {
-      fontSize: yomoyoTypography.screenBodySize,
-      color: colors.muted,
-      marginBottom: spacing.sm,
     },
     cta: {
       flexDirection: 'row',


### PR DESCRIPTION
Address A-1 from the #111 flow analysis: replace the flat empty-shelf text with a centered EmptyState (book icon + 'record your first book' title + message). The always-visible add-book FAB stays as the single action, so the first step is clear without duplicating the CTA.