### PR TITLE
feat: gate ads behind Google UMP consent (#102, UMP only)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import { StatusBar } from 'expo-status-bar';
 import RootNavigator from '@/navigation/RootNavigator';
 import i18n, { loadSavedLanguage } from '@/lib/i18n';
 import { linkingConfig } from '@/navigation/linkingConfig';
-import { initAdMob } from '@/lib/ads/initAdMob';
+import { AdConsentProvider } from '@/lib/ads/AdConsentContext';
 import { ThemeProvider, useTheme } from '@/lib/theme';
 
 function ThemedRoot() {
@@ -45,16 +45,14 @@ export default function App() {
       .catch(() => setReady(true));
   }, []);
 
-  useEffect(() => {
-    void initAdMob();
-  }, []);
-
   if (!ready) return null;
 
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <ThemedRoot />
+        <AdConsentProvider>
+          <ThemedRoot />
+        </AdConsentProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/__mocks__/react-native-google-mobile-ads.js
+++ b/__mocks__/react-native-google-mobile-ads.js
@@ -8,8 +8,8 @@ const instance = {
 };
 const mobileAds = jest.fn(() => instance);
 
-const BannerAd = ({ unitId, size }) =>
-  React.createElement(View, { testID: 'timeline-banner-ad', unitId, size });
+const BannerAd = ({ unitId, size, requestOptions }) =>
+  React.createElement(View, { testID: 'timeline-banner-ad', unitId, size, requestOptions });
 
 const BannerAdSize = {
   ANCHORED_ADAPTIVE_BANNER: 'ANCHORED_ADAPTIVE_BANNER',
@@ -24,10 +24,30 @@ const TestIds = {
   REWARDED: 'ca-app-pub-3940256099942544/5224354917',
 };
 
+const AdsConsentStatus = {
+  UNKNOWN: 'UNKNOWN',
+  REQUIRED: 'REQUIRED',
+  NOT_REQUIRED: 'NOT_REQUIRED',
+  OBTAINED: 'OBTAINED',
+};
+
+const AdsConsent = {
+  requestInfoUpdate: jest.fn(() => Promise.resolve({ status: 'NOT_REQUIRED' })),
+  loadAndShowConsentFormIfRequired: jest.fn(() =>
+    Promise.resolve({ status: 'NOT_REQUIRED' }),
+  ),
+  getConsentInfo: jest.fn(() =>
+    Promise.resolve({ status: 'NOT_REQUIRED', canRequestAds: true }),
+  ),
+  getPurposeConsents: jest.fn(() => Promise.resolve('')),
+};
+
 module.exports = {
   __esModule: true,
   default: mobileAds,
   BannerAd,
   BannerAdSize,
   TestIds,
+  AdsConsentStatus,
+  AdsConsent,
 };

--- a/src/components/ads/TimelineBannerAd.test.tsx
+++ b/src/components/ads/TimelineBannerAd.test.tsx
@@ -15,4 +15,10 @@ describe('TimelineBannerAd', () => {
     const banner = screen.getByTestId('timeline-banner-ad');
     expect(banner.props.size).toBe('ANCHORED_ADAPTIVE_BANNER');
   });
+
+  it('requests non-personalized ads by default (privacy-safe before consent)', () => {
+    render(<TimelineBannerAd />);
+    const banner = screen.getByTestId('timeline-banner-ad');
+    expect(banner.props.requestOptions).toEqual({ requestNonPersonalizedAdsOnly: true });
+  });
 });

--- a/src/components/ads/TimelineBannerAd.tsx
+++ b/src/components/ads/TimelineBannerAd.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { BannerAd, BannerAdSize } from 'react-native-google-mobile-ads';
 import { bannerAdUnitId } from '@/lib/ads/adUnitIds';
+import { useAdConsent } from '@/lib/ads/AdConsentContext';
 import AdErrorBoundary from './AdErrorBoundary';
 
 const TimelineBannerAd = React.memo(function TimelineBannerAd() {
+  const { requestNonPersonalizedAdsOnly } = useAdConsent();
   return (
     <AdErrorBoundary>
-      <BannerAd unitId={bannerAdUnitId} size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER} />
+      <BannerAd
+        unitId={bannerAdUnitId}
+        size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
+        requestOptions={{ requestNonPersonalizedAdsOnly }}
+      />
     </AdErrorBoundary>
   );
 });

--- a/src/lib/ads/AdConsentContext.test.tsx
+++ b/src/lib/ads/AdConsentContext.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen, waitFor } from '@testing-library/react-native';
+import { AdConsentProvider, useAdConsent } from './AdConsentContext';
+import { AdsConsent } from 'react-native-google-mobile-ads';
+
+const mockAdsConsent = AdsConsent as jest.Mocked<typeof AdsConsent>;
+
+function Probe() {
+  const { requestNonPersonalizedAdsOnly } = useAdConsent();
+  return <Text testID="npa">{String(requestNonPersonalizedAdsOnly)}</Text>;
+}
+
+describe('AdConsentContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the privacy-safe default (NPA) when used without a provider', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('npa').props.children).toBe('true');
+  });
+
+  it('resolves to personalized ads once consent is gathered (NOT_REQUIRED region)', async () => {
+    mockAdsConsent.getConsentInfo.mockResolvedValue({ status: 'NOT_REQUIRED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValue('');
+    render(
+      <AdConsentProvider>
+        <Probe />
+      </AdConsentProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('npa').props.children).toBe('false');
+    });
+  });
+
+  it('keeps non-personalized ads when consent is not granted', async () => {
+    mockAdsConsent.getConsentInfo.mockResolvedValue({ status: 'REQUIRED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValue('');
+    render(
+      <AdConsentProvider>
+        <Probe />
+      </AdConsentProvider>,
+    );
+    await waitFor(() => {
+      expect(mockAdsConsent.requestInfoUpdate).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('npa').props.children).toBe('true');
+  });
+});

--- a/src/lib/ads/AdConsentContext.tsx
+++ b/src/lib/ads/AdConsentContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { gatherAdConsent } from './adConsent';
+import { initAdMob } from './initAdMob';
+
+export type AdConsentValue = {
+  requestNonPersonalizedAdsOnly: boolean;
+};
+
+// Privacy-safe default: non-personalized until UMP consent resolves, so no
+// tracking ad request can fire before consent is known.
+const AdConsentContext = createContext<AdConsentValue>({
+  requestNonPersonalizedAdsOnly: true,
+});
+
+export function AdConsentProvider({ children }: { children: React.ReactNode }) {
+  const [requestNonPersonalizedAdsOnly, setNonPersonalized] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    // Gather consent first, then initialize the Ads SDK — UMP must precede ads.
+    gatherAdConsent()
+      .then((nonPersonalized) => {
+        if (active) setNonPersonalized(nonPersonalized);
+      })
+      .finally(() => {
+        void initAdMob();
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <AdConsentContext.Provider value={{ requestNonPersonalizedAdsOnly }}>
+      {children}
+    </AdConsentContext.Provider>
+  );
+}
+
+export function useAdConsent(): AdConsentValue {
+  return useContext(AdConsentContext);
+}

--- a/src/lib/ads/adConsent.test.ts
+++ b/src/lib/ads/adConsent.test.ts
@@ -1,0 +1,63 @@
+import { shouldRequestNonPersonalizedAds, gatherAdConsent } from './adConsent';
+import { AdsConsent } from 'react-native-google-mobile-ads';
+
+const mockAdsConsent = AdsConsent as jest.Mocked<typeof AdsConsent>;
+
+describe('shouldRequestNonPersonalizedAds', () => {
+  it('serves personalized ads outside GDPR (NOT_REQUIRED)', () => {
+    expect(shouldRequestNonPersonalizedAds('NOT_REQUIRED')).toBe(false);
+  });
+
+  it('serves personalized ads when consent is OBTAINED and purpose 1 is granted', () => {
+    expect(shouldRequestNonPersonalizedAds('OBTAINED', '1')).toBe(false);
+  });
+
+  it('serves non-personalized ads when consent is OBTAINED but purpose 1 is denied', () => {
+    expect(shouldRequestNonPersonalizedAds('OBTAINED', '0')).toBe(true);
+  });
+
+  it('serves non-personalized ads when consent is OBTAINED but no purpose string', () => {
+    expect(shouldRequestNonPersonalizedAds('OBTAINED', '')).toBe(true);
+    expect(shouldRequestNonPersonalizedAds('OBTAINED', undefined)).toBe(true);
+  });
+
+  it('serves non-personalized ads before consent is granted (REQUIRED / UNKNOWN)', () => {
+    expect(shouldRequestNonPersonalizedAds('REQUIRED')).toBe(true);
+    expect(shouldRequestNonPersonalizedAds('UNKNOWN')).toBe(true);
+  });
+});
+
+describe('gatherAdConsent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests an info update and shows the consent form if required', async () => {
+    await gatherAdConsent();
+    expect(mockAdsConsent.requestInfoUpdate).toHaveBeenCalled();
+    expect(mockAdsConsent.loadAndShowConsentFormIfRequired).toHaveBeenCalled();
+  });
+
+  it('returns personalized (false) when status is NOT_REQUIRED', async () => {
+    mockAdsConsent.getConsentInfo.mockResolvedValueOnce({ status: 'NOT_REQUIRED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValueOnce('');
+    await expect(gatherAdConsent()).resolves.toBe(false);
+  });
+
+  it('returns personalized (false) when consent obtained with purpose 1 granted', async () => {
+    mockAdsConsent.getConsentInfo.mockResolvedValueOnce({ status: 'OBTAINED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValueOnce('1');
+    await expect(gatherAdConsent()).resolves.toBe(false);
+  });
+
+  it('returns non-personalized (true) when consent obtained but purpose 1 denied', async () => {
+    mockAdsConsent.getConsentInfo.mockResolvedValueOnce({ status: 'OBTAINED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValueOnce('0');
+    await expect(gatherAdConsent()).resolves.toBe(true);
+  });
+
+  it('falls back to non-personalized (true) when the UMP flow throws', async () => {
+    mockAdsConsent.requestInfoUpdate.mockRejectedValueOnce(new Error('boom'));
+    await expect(gatherAdConsent()).resolves.toBe(true);
+  });
+});

--- a/src/lib/ads/adConsent.ts
+++ b/src/lib/ads/adConsent.ts
@@ -1,0 +1,39 @@
+import { AdsConsent } from 'react-native-google-mobile-ads';
+
+/**
+ * Decide whether ads must be requested as non-personalized (NPA), from the UMP
+ * consent status and the TCF purpose-consent string.
+ *
+ * Privacy-safe by default: anything other than an explicit "personalized is OK"
+ * yields NPA = true, so the app never serves tracking ads without consent.
+ */
+export function shouldRequestNonPersonalizedAds(
+  status: string,
+  purposeConsents?: string,
+): boolean {
+  if (status === 'NOT_REQUIRED') return false; // outside GDPR — personalized OK
+  if (status === 'OBTAINED') {
+    // TCF purpose 1 = "Store and/or access information on a device".
+    return purposeConsents?.charAt(0) !== '1';
+  }
+  // REQUIRED or UNKNOWN: consent not yet granted — never track before consent.
+  return true;
+}
+
+/**
+ * Run the Google UMP consent flow at startup and resolve whether ad requests
+ * must be non-personalized. Failures resolve to the privacy-safe default (NPA).
+ */
+export async function gatherAdConsent(): Promise<boolean> {
+  try {
+    await AdsConsent.requestInfoUpdate();
+    await AdsConsent.loadAndShowConsentFormIfRequired();
+    const info = await AdsConsent.getConsentInfo();
+    const purposeConsents = await AdsConsent.getPurposeConsents();
+    return shouldRequestNonPersonalizedAds(info.status, purposeConsents);
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('[gatherAdConsent] UMP flow failed —', e?.message ?? err);
+    return true;
+  }
+}

--- a/src/types/react-native-google-mobile-ads.d.ts
+++ b/src/types/react-native-google-mobile-ads.d.ts
@@ -20,9 +20,14 @@ declare module 'react-native-google-mobile-ads' {
     REWARDED: string;
   };
 
+  export interface BannerAdRequestOptions {
+    requestNonPersonalizedAdsOnly?: boolean;
+  }
+
   export interface BannerAdProps {
     unitId: string;
     size: BannerAdSizeValue;
+    requestOptions?: BannerAdRequestOptions;
   }
 
   export const BannerAd: React.ComponentType<BannerAdProps>;
@@ -34,4 +39,25 @@ declare module 'react-native-google-mobile-ads' {
 
   const mobileAds: () => MobileAdsInstance;
   export default mobileAds;
+
+  export type AdsConsentStatusValue = 'UNKNOWN' | 'REQUIRED' | 'NOT_REQUIRED' | 'OBTAINED';
+
+  export const AdsConsentStatus: {
+    UNKNOWN: 'UNKNOWN';
+    REQUIRED: 'REQUIRED';
+    NOT_REQUIRED: 'NOT_REQUIRED';
+    OBTAINED: 'OBTAINED';
+  };
+
+  export interface AdsConsentInfo {
+    status: AdsConsentStatusValue;
+    canRequestAds?: boolean;
+  }
+
+  export const AdsConsent: {
+    requestInfoUpdate: (options?: Record<string, unknown>) => Promise<AdsConsentInfo>;
+    loadAndShowConsentFormIfRequired: () => Promise<AdsConsentInfo>;
+    getConsentInfo: () => Promise<AdsConsentInfo>;
+    getPurposeConsents: () => Promise<string>;
+  };
 }


### PR DESCRIPTION
Part of
  #102. Google UMP 同意フローを広告初期化前に実行し、同意状態に応じて requestNonPersonalizedAdsOnly
  を切替。同意解決まで NPA=true（トラッキング前ロード防止）。**ATT プロンプトと NSUserTrackingUsageDescription
  は別PRに後回し**（ネイティブ tracking-transparency モジュールが必要）。実機での同意フォーム表示確認は TODO。