### PR TITLE
feat: request iOS ATT after UMP consent (#102)

### DIFF
--- a/__mocks__/expo-tracking-transparency.js
+++ b/__mocks__/expo-tracking-transparency.js
@@ -1,0 +1,12 @@
+const granted = {
+  status: 'granted',
+  granted: true,
+  canAskAgain: true,
+  expires: 'never',
+};
+
+module.exports = {
+  __esModule: true,
+  requestTrackingPermissionsAsync: jest.fn(() => Promise.resolve(granted)),
+  getTrackingPermissionsAsync: jest.fn(() => Promise.resolve(granted)),
+};

--- a/app.json
+++ b/app.json
@@ -55,6 +55,12 @@
         {
           "cameraPermission": "Yomoyo uses the camera to scan book barcodes for quick registration."
         }
+      ],
+      [
+        "expo-tracking-transparency",
+        {
+          "userTrackingPermission": "Yomoyo uses this to measure ad performance and show more relevant ads. Tracking is only used if you allow it."
+        }
       ]
     ],
     "extra": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-dev-client": "~6.0.21",
     "expo-notifications": "^55.0.22",
     "expo-status-bar": "~3.0.9",
+    "expo-tracking-transparency": "~6.0.8",
     "expo-video": "~2.0.5",
     "i18next": "^26.0.8",
     "react": "19.1.0",
@@ -79,6 +80,7 @@
       "expo-camera": "<rootDir>/__mocks__/expo-camera.js",
       "expo-video": "<rootDir>/__mocks__/expo-video.js",
       "expo-blur": "<rootDir>/__mocks__/expo-blur.js",
+      "expo-tracking-transparency": "<rootDir>/__mocks__/expo-tracking-transparency.js",
       "react-native-google-mobile-ads": "<rootDir>/__mocks__/react-native-google-mobile-ads.js"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-tracking-transparency:
+        specifier: ~6.0.8
+        version: 6.0.8(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       expo-video:
         specifier: ~2.0.5
         version: 2.0.6(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1664,6 +1667,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2774,6 +2778,12 @@ packages:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
       react: '*'
+      react-native: '*'
+
+  expo-tracking-transparency@6.0.8:
+    resolution: {integrity: sha512-4/NW47Kmrtj3J0udUmzxiq01gRY+vG8wFsUop6CTOVWlk+2MypjDFwBSscHcyiS2dJGNQLOQSBZ1RNhLdgSBOQ==}
+    peerDependencies:
+      expo: '*'
       react-native: '*'
 
   expo-updates-interface@2.0.0:
@@ -5149,6 +5159,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
@@ -8874,6 +8885,11 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-tracking-transparency@6.0.8(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   expo-updates-interface@2.0.0(expo@54.0.34(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:

--- a/src/lib/ads/AdConsentContext.test.tsx
+++ b/src/lib/ads/AdConsentContext.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, Platform } from 'react-native';
 import { render, screen, waitFor } from '@testing-library/react-native';
 import { AdConsentProvider, useAdConsent } from './AdConsentContext';
 import { AdsConsent } from 'react-native-google-mobile-ads';
+import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 
 const mockAdsConsent = AdsConsent as jest.Mocked<typeof AdsConsent>;
+const mockRequestTracking = requestTrackingPermissionsAsync as jest.Mock;
 
 function Probe() {
   const { requestNonPersonalizedAdsOnly } = useAdConsent();
@@ -46,5 +48,20 @@ describe('AdConsentContext', () => {
       expect(mockAdsConsent.requestInfoUpdate).toHaveBeenCalled();
     });
     expect(screen.getByTestId('npa').props.children).toBe('true');
+  });
+
+  it('forces non-personalized ads when ATT tracking is denied even if UMP allows it', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+    mockAdsConsent.getConsentInfo.mockResolvedValue({ status: 'NOT_REQUIRED' });
+    mockAdsConsent.getPurposeConsents.mockResolvedValue('');
+    mockRequestTracking.mockResolvedValue({ status: 'denied', granted: false });
+    render(
+      <AdConsentProvider>
+        <Probe />
+      </AdConsentProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('npa').props.children).toBe('true');
+    });
   });
 });

--- a/src/lib/ads/AdConsentContext.tsx
+++ b/src/lib/ads/AdConsentContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { gatherAdConsent } from './adConsent';
+import { requestAttPermission } from './requestAttPermission';
 import { initAdMob } from './initAdMob';
 
 export type AdConsentValue = {
@@ -17,14 +18,14 @@ export function AdConsentProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let active = true;
-    // Gather consent first, then initialize the Ads SDK — UMP must precede ads.
-    gatherAdConsent()
-      .then((nonPersonalized) => {
-        if (active) setNonPersonalized(nonPersonalized);
-      })
-      .finally(() => {
-        void initAdMob();
-      });
+    // Order matters: UMP consent first, then iOS ATT, then initialize ads.
+    // Ads are non-personalized if UMP withholds consent OR ATT is not granted.
+    (async () => {
+      const umpNonPersonalized = await gatherAdConsent();
+      const trackingGranted = await requestAttPermission();
+      if (active) setNonPersonalized(umpNonPersonalized || !trackingGranted);
+      void initAdMob();
+    })();
     return () => {
       active = false;
     };

--- a/src/lib/ads/requestAttPermission.test.ts
+++ b/src/lib/ads/requestAttPermission.test.ts
@@ -1,0 +1,45 @@
+import { Platform } from 'react-native';
+import { requestAttPermission } from './requestAttPermission';
+import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
+
+const mockRequest = requestTrackingPermissionsAsync as jest.Mock;
+const originalOS = Platform.OS;
+
+function setOS(os: string) {
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+}
+
+describe('requestAttPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setOS(originalOS);
+  });
+
+  it('returns true without prompting on non-iOS platforms', async () => {
+    setOS('android');
+    await expect(requestAttPermission()).resolves.toBe(true);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('requests tracking permission on iOS and returns true when granted', async () => {
+    setOS('ios');
+    mockRequest.mockResolvedValueOnce({ status: 'granted', granted: true });
+    await expect(requestAttPermission()).resolves.toBe(true);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false on iOS when the user denies tracking', async () => {
+    setOS('ios');
+    mockRequest.mockResolvedValueOnce({ status: 'denied', granted: false });
+    await expect(requestAttPermission()).resolves.toBe(false);
+  });
+
+  it('returns false on iOS when the request throws', async () => {
+    setOS('ios');
+    mockRequest.mockRejectedValueOnce(new Error('boom'));
+    await expect(requestAttPermission()).resolves.toBe(false);
+  });
+});

--- a/src/lib/ads/requestAttPermission.ts
+++ b/src/lib/ads/requestAttPermission.ts
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native';
+import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
+
+/**
+ * Request iOS App Tracking Transparency permission.
+ *
+ * Must be called AFTER the UMP consent flow (Google requires UMP → ATT order).
+ * Returns whether the user granted tracking (IDFA access). Non-iOS platforms
+ * have no ATT and resolve true without prompting; failures resolve false so the
+ * app stays on the privacy-safe (non-personalized) path.
+ */
+export async function requestAttPermission(): Promise<boolean> {
+  if (Platform.OS !== 'ios') return true;
+  try {
+    const { granted } = await requestTrackingPermissionsAsync();
+    return granted;
+  } catch (err) {
+    const e = err as { message?: string };
+    console.error('[requestAttPermission] ATT request failed —', e?.message ?? err);
+    return false;
+  }
+}

--- a/src/types/expo-tracking-transparency.d.ts
+++ b/src/types/expo-tracking-transparency.d.ts
@@ -1,0 +1,18 @@
+// Ambient shim so the project type-checks before `expo-tracking-transparency`
+// is installed in this sandbox. Mirrors the package's public API.
+//
+// After running `pnpm install` (which installs the real package with its own
+// types), delete this file if you hit duplicate-declaration errors.
+declare module 'expo-tracking-transparency' {
+  export type PermissionStatus = 'granted' | 'denied' | 'undetermined';
+
+  export interface PermissionResponse {
+    status: PermissionStatus;
+    granted: boolean;
+    canAskAgain: boolean;
+    expires: 'never' | number;
+  }
+
+  export function requestTrackingPermissionsAsync(): Promise<PermissionResponse>;
+  export function getTrackingPermissionsAsync(): Promise<PermissionResponse>;
+}


### PR DESCRIPTION
Closes #102
  (ATT部分)。expo-tracking-transparency を追加し、UMP の後に ATT を要求。ATT拒否時はNPA強制。app.json に
  NSUserTrackingUsageDescription(config
  plugin)。型shim+jestモックで未インストールでもCI緑。実機でUMP→ATT順を要確認。