### PR TITLE
feat: add loading skeletons for feed, shelf and profile

### DIFF
--- a/src/components/books/BookListSkeleton.test.tsx
+++ b/src/components/books/BookListSkeleton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import BookListSkeleton from './BookListSkeleton';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+describe('BookListSkeleton', () => {
+  it('renders the default number of placeholder rows', () => {
+    render(<BookListSkeleton />);
+    expect(screen.getAllByTestId('book-list-skeleton-row')).toHaveLength(4);
+  });
+
+  it('renders a custom number of placeholder rows', () => {
+    render(<BookListSkeleton count={3} />);
+    expect(screen.getAllByTestId('book-list-skeleton-row')).toHaveLength(3);
+  });
+
+  it('exposes a single loading label to assistive technologies', () => {
+    render(<BookListSkeleton />);
+    const group = screen.getByTestId('book-list-skeleton');
+    expect(group.props.accessibilityLabel).toBe('common.loading');
+    expect(group.props.accessibilityState).toEqual({ busy: true });
+  });
+});

--- a/src/components/books/BookListSkeleton.tsx
+++ b/src/components/books/BookListSkeleton.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Skeleton from '@/components/ui/Skeleton';
+import { spacing } from '@/constants/yomoyoTheme';
+import { useThemedStyles, type ThemeColors } from '@/lib/theme';
+
+const DEFAULT_COUNT = 4;
+const THUMB_WIDTH = 52;
+const THUMB_HEIGHT = 72;
+
+export type BookListSkeletonProps = {
+  /** Number of placeholder rows to render. */
+  count?: number;
+};
+
+/**
+ * Loading placeholder for finished-book lists (Shelf, user profiles). Mirrors
+ * the layout of {@link BookListItem} for a stable load-to-content transition.
+ */
+export default function BookListSkeleton({ count = DEFAULT_COUNT }: BookListSkeletonProps) {
+  const { t } = useTranslation();
+  const styles = useThemedStyles(makeStyles);
+
+  return (
+    <View
+      testID="book-list-skeleton"
+      accessibilityRole="progressbar"
+      accessibilityLabel={t('common.loading')}
+      accessibilityState={{ busy: true }}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <View key={index} testID="book-list-skeleton-row" style={styles.card}>
+          <Skeleton width={THUMB_WIDTH} height={THUMB_HEIGHT} borderRadius={6} style={styles.thumbnail} />
+          <View style={styles.info}>
+            <Skeleton width="70%" height={15} />
+            <Skeleton width="45%" height={13} style={styles.author} />
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    card: {
+      flexDirection: 'row',
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: spacing.md,
+      marginBottom: spacing.md,
+    },
+    thumbnail: {
+      marginRight: spacing.md,
+    },
+    info: {
+      flex: 1,
+      justifyContent: 'center',
+    },
+    author: {
+      marginTop: spacing.sm,
+    },
+  });

--- a/src/components/feed/FeedSkeleton.test.tsx
+++ b/src/components/feed/FeedSkeleton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import FeedSkeleton from './FeedSkeleton';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+describe('FeedSkeleton', () => {
+  it('renders the default number of placeholder cards', () => {
+    render(<FeedSkeleton />);
+    expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(5);
+  });
+
+  it('renders a custom number of placeholder cards', () => {
+    render(<FeedSkeleton count={2} />);
+    expect(screen.getAllByTestId('feed-skeleton-card')).toHaveLength(2);
+  });
+
+  it('exposes a single loading label to assistive technologies', () => {
+    render(<FeedSkeleton />);
+    const group = screen.getByTestId('feed-skeleton');
+    expect(group.props.accessibilityLabel).toBe('common.loading');
+    expect(group.props.accessibilityState).toEqual({ busy: true });
+  });
+});

--- a/src/components/feed/FeedSkeleton.tsx
+++ b/src/components/feed/FeedSkeleton.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Skeleton from '@/components/ui/Skeleton';
+import { spacing } from '@/constants/yomoyoTheme';
+import { useThemedStyles, type ThemeColors } from '@/lib/theme';
+
+const DEFAULT_COUNT = 5;
+const AVATAR_SIZE = 32;
+const THUMB_WIDTH = 52;
+const THUMB_HEIGHT = 72;
+const THUMB_RADIUS = 6;
+const NAME_WIDTH = 120;
+const LINE_HEIGHT = 14;
+const DATE_HEIGHT = 12;
+const TITLE_WIDTH = '80%';
+const DATE_WIDTH = '40%';
+
+export type FeedSkeletonProps = {
+  /** Number of placeholder cards to render. */
+  count?: number;
+};
+
+/**
+ * Loading placeholder for the timeline / bookmarks feed. Mirrors the layout of
+ * {@link ActivityCard} so the transition to real content is visually stable.
+ */
+export default function FeedSkeleton({ count = DEFAULT_COUNT }: FeedSkeletonProps) {
+  const { t } = useTranslation();
+  const styles = useThemedStyles(makeStyles);
+
+  return (
+    <View
+      testID="feed-skeleton"
+      style={styles.list}
+      accessibilityRole="progressbar"
+      accessibilityLabel={t('common.loading')}
+      accessibilityState={{ busy: true }}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <View key={index} testID="feed-skeleton-card" style={styles.card}>
+          <View style={styles.header}>
+            <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} borderRadius={AVATAR_SIZE / 2} />
+            <Skeleton width={NAME_WIDTH} height={LINE_HEIGHT} style={styles.name} />
+          </View>
+          <View style={styles.body}>
+            <Skeleton width={THUMB_WIDTH} height={THUMB_HEIGHT} borderRadius={THUMB_RADIUS} />
+            <View style={styles.info}>
+              <Skeleton width={TITLE_WIDTH} height={LINE_HEIGHT} />
+              <Skeleton width={DATE_WIDTH} height={DATE_HEIGHT} style={styles.date} />
+            </View>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    list: { paddingBottom: spacing.lg },
+    card: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: spacing.md,
+      marginBottom: spacing.md,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: spacing.sm,
+    },
+    name: {
+      marginLeft: spacing.sm,
+    },
+    body: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+    },
+    info: {
+      flex: 1,
+      marginLeft: spacing.md,
+      justifyContent: 'center',
+    },
+    date: {
+      marginTop: spacing.sm,
+    },
+  });

--- a/src/components/ui/Skeleton.test.tsx
+++ b/src/components/ui/Skeleton.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { AccessibilityInfo } from 'react-native';
+import { screen } from '@testing-library/react-native';
+import { renderWithTheme as render } from '@/lib/theme/testUtils';
+import Skeleton from './Skeleton';
+
+// The block is intentionally hidden from the accessibility tree, so queries
+// must opt into hidden elements to reach it.
+const HIDDEN = { includeHiddenElements: true } as const;
+
+describe('Skeleton', () => {
+  it('renders a block with the given testID', () => {
+    render(<Skeleton testID="sk" />);
+    expect(screen.getByTestId('sk', HIDDEN)).toBeTruthy();
+  });
+
+  it('applies the provided width, height and borderRadius', () => {
+    render(<Skeleton testID="sk" width={120} height={20} borderRadius={4} />);
+    const node = screen.getByTestId('sk', HIDDEN);
+    expect(node.props.style).toEqual(
+      expect.objectContaining({ width: 120, height: 20, borderRadius: 4 }),
+    );
+  });
+
+  it('is hidden from assistive technologies (decorative)', () => {
+    render(<Skeleton testID="sk" />);
+    const node = screen.getByTestId('sk', HIDDEN);
+    expect(node.props.accessibilityElementsHidden).toBe(true);
+    expect(node.props.importantForAccessibility).toBe('no-hide-descendants');
+  });
+
+  it('checks the reduce-motion setting before animating', () => {
+    const spy = jest
+      .spyOn(AccessibilityInfo, 'isReduceMotionEnabled')
+      .mockResolvedValue(true);
+    render(<Skeleton testID="sk" />);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  AccessibilityInfo,
+  Animated,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { useTheme } from '@/lib/theme';
+
+const PULSE_MIN_OPACITY = 0.4;
+const PULSE_MAX_OPACITY = 1;
+const PULSE_DURATION_MS = 800;
+const DEFAULT_HEIGHT = 16;
+const DEFAULT_RADIUS = 6;
+
+export type SkeletonProps = {
+  /** Block width. Accepts any RN dimension value (number or percentage string). */
+  width?: ViewStyle['width'];
+  height?: number;
+  borderRadius?: number;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+/**
+ * A single placeholder block that pulses while content loads.
+ *
+ * Purely decorative: hidden from screen readers (the enclosing skeleton group
+ * exposes a single "loading" label). Honors the OS "reduce motion" setting by
+ * skipping the pulse animation.
+ */
+export default function Skeleton({
+  width = '100%',
+  height = DEFAULT_HEIGHT,
+  borderRadius = DEFAULT_RADIUS,
+  style,
+  testID,
+}: SkeletonProps) {
+  const { colors } = useTheme();
+  const opacity = useRef(new Animated.Value(PULSE_MAX_OPACITY)).current;
+
+  useEffect(() => {
+    let cancelled = false;
+    let loop: Animated.CompositeAnimation | null = null;
+
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((reduceMotion) => {
+        if (cancelled || reduceMotion) return;
+        loop = Animated.loop(
+          Animated.sequence([
+            Animated.timing(opacity, {
+              toValue: PULSE_MIN_OPACITY,
+              duration: PULSE_DURATION_MS,
+              useNativeDriver: true,
+            }),
+            Animated.timing(opacity, {
+              toValue: PULSE_MAX_OPACITY,
+              duration: PULSE_DURATION_MS,
+              useNativeDriver: true,
+            }),
+          ]),
+        );
+        loop.start();
+      })
+      .catch(() => {
+        // Reduce-motion lookup is best-effort; fall back to a static block.
+      });
+
+    return () => {
+      cancelled = true;
+      loop?.stop();
+    };
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      testID={testID}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        { width, height, borderRadius, backgroundColor: colors.border, opacity },
+        style,
+      ]}
+    />
+  );
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1,6 +1,7 @@
 const en = {
   common: {
     back: 'Go back',
+    loading: 'Loading',
   },
   tabs: {
     timeline: 'Timeline',

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -1,6 +1,7 @@
 const ja = {
   common: {
     back: '戻る',
+    loading: '読み込み中',
   },
   tabs: {
     timeline: 'タイムライン',

--- a/src/screens/FeedScreen.hooks.ts
+++ b/src/screens/FeedScreen.hooks.ts
@@ -60,7 +60,9 @@ export function useFeedState(): FeedState {
   const [items, setItems] = useState<ReadingActivity[]>([]);
   const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot | null>(null);
   const [followingUids, setFollowingUids] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Start in the loading state so the first paint shows the skeleton rather
+  // than briefly flashing the empty state before the load effect runs.
+  const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
@@ -71,7 +73,10 @@ export function useFeedState(): FeedState {
 
   useEffect(() => {
     const uid = user?.uid;
-    if (!uid) return;
+    if (!uid) {
+      setIsLoading(false);
+      return;
+    }
     let cancelled = false;
     setIsLoading(true);
     setHasError(false);

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -20,7 +20,8 @@ import { formatBookDate } from '@/lib/books/formatBookDate';
 import TimelineBannerAd from '@/components/ads/TimelineBannerAd';
 import { useGlassTabBarInset } from '@/components/ui/GlassTabBar';
 import { yomoyoTypography } from '@/constants/yomoyoTheme';
-import { useTheme, useThemedStyles, type ThemeColors } from '@/lib/theme';
+import { useThemedStyles, type ThemeColors } from '@/lib/theme';
+import FeedSkeleton from '@/components/feed/FeedSkeleton';
 import { ANIMAL_ASSETS } from '@/lib/users/avatarIdentity';
 import type { AnimalKey } from '@/lib/users/avatarIdentity';
 import type { ReadingActivity } from '@/lib/books/readingActivity';
@@ -132,7 +133,6 @@ export default function FeedScreen() {
     toggleBookmark,
   } = useFeedState();
   const { mode } = useBookmarkFilter();
-  const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
 
   const [selectedActivity, setSelectedActivity] = useState<ReadingActivity | null>(null);
@@ -214,9 +214,7 @@ export default function FeedScreen() {
   return (
     <ScreenContainer bottomInset={tabBarInset}>
       {isLoading ? (
-        <View style={styles.center}>
-          <ActivityIndicator color={colors.primary} />
-        </View>
+        <FeedSkeleton />
       ) : hasError ? (
         <EmptyState
           icon="cloud-offline-outline"
@@ -250,12 +248,6 @@ export default function FeedScreen() {
 
 const makeStyles = (colors: ThemeColors) =>
   StyleSheet.create({
-    center: {
-      flex: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingHorizontal: 32,
-    },
     list: { paddingBottom: 16 },
     loader: { marginVertical: 16 },
     adSlot: { marginBottom: 12, alignItems: 'center' },

--- a/src/screens/ShelfScreen.test.tsx
+++ b/src/screens/ShelfScreen.test.tsx
@@ -77,18 +77,36 @@ describe('ShelfScreen', () => {
   });
 
   it('shows empty Finished state when no finished books exist', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([]);
+      return jest.fn();
+    });
     render(<ShelfScreen />);
     expect(screen.getByText('shelf.emptyFinished')).toBeTruthy();
   });
 
   it('guides the user to record their first book in the empty state', () => {
+    mockSubscribe.mockImplementation((_userId: string, onUpdate: Function) => {
+      onUpdate([]);
+      return jest.fn();
+    });
     render(<ShelfScreen />);
     expect(screen.getByText('shelf.emptyTitle')).toBeTruthy();
   });
 
+  it('shows a loading skeleton until the first snapshot arrives', () => {
+    render(<ShelfScreen />);
+    expect(screen.getByTestId('book-list-skeleton')).toBeTruthy();
+    expect(screen.queryByText('shelf.emptyFinished')).toBeNull();
+  });
+
   it('subscribes to activities for the current user on mount', () => {
     render(<ShelfScreen />);
-    expect(mockSubscribe).toHaveBeenCalledWith('user1', expect.any(Function));
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'user1',
+      expect.any(Function),
+      expect.any(Function),
+    );
   });
 
   it('renders book title when finished activities exist', () => {

--- a/src/screens/ShelfScreen.tsx
+++ b/src/screens/ShelfScreen.tsx
@@ -18,6 +18,7 @@ import type { RootStackParamList } from '@/navigation/types';
 import MyHandleCard from '@/components/shelf/MyHandleCard';
 import MyIdentityHeader from '@/components/shelf/MyIdentityHeader';
 import BookListItem from '@/components/books/BookListItem';
+import BookListSkeleton from '@/components/books/BookListSkeleton';
 import EmptyState from '@/components/ui/EmptyState';
 import { formatBookDate } from '@/lib/books/formatBookDate';
 
@@ -34,11 +35,23 @@ export default function ShelfScreen() {
   const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
   const [activities, setActivities] = useState<ReadingActivity[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const uid = user?.uid;
-    if (!uid) return;
-    const unsubscribe = subscribeToReadingActivities(uid, setActivities);
+    if (!uid) {
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    const unsubscribe = subscribeToReadingActivities(
+      uid,
+      (items) => {
+        setActivities(items);
+        setIsLoading(false);
+      },
+      () => setIsLoading(false),
+    );
     return unsubscribe;
   }, [user?.uid]);
 
@@ -77,7 +90,9 @@ export default function ShelfScreen() {
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
-        {activities.length === 0 ? (
+        {isLoading ? (
+          <BookListSkeleton />
+        ) : activities.length === 0 ? (
           <EmptyState
             icon="book-outline"
             title={t('shelf.emptyTitle')}

--- a/src/screens/UserProfileScreen.test.tsx
+++ b/src/screens/UserProfileScreen.test.tsx
@@ -143,9 +143,20 @@ describe('UserProfileScreen — book list', () => {
   });
 
   it('shows empty state when no finished books', async () => {
+    mockSubscribe.mockImplementation((_uid: string, onUpdate: Function) => {
+      onUpdate([]);
+      return jest.fn();
+    });
+    render(<UserProfileScreen />);
+    await screen.findByText('userProfile.emptyBooks');
+    expect(screen.getByText('userProfile.emptyBooks')).toBeTruthy();
+  });
+
+  it('shows a loading skeleton until the first activities snapshot arrives', async () => {
     render(<UserProfileScreen />);
     await screen.findByText('Quiet Fox');
-    expect(screen.getByText('userProfile.emptyBooks')).toBeTruthy();
+    expect(screen.getByTestId('book-list-skeleton')).toBeTruthy();
+    expect(screen.queryByText('userProfile.emptyBooks')).toBeNull();
   });
 
   it('hides empty state when books exist', async () => {

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -15,6 +15,7 @@ import type { ReadingActivity } from '@/lib/books/readingActivity';
 import { bucketActivitiesByWeek, HISTORY_WINDOW_WEEKS } from '@/lib/books/readingHistory';
 import ReadingHistoryHeatmap from '@/components/profile/ReadingHistoryHeatmap';
 import BookListItem from '@/components/books/BookListItem';
+import BookListSkeleton from '@/components/books/BookListSkeleton';
 import { isFollowing, followUser, unfollowUser } from '@/lib/users/follows';
 import type { RootStackParamList } from '@/navigation/types';
 import { yomoyoTypography, spacing } from '@/constants/yomoyoTheme';
@@ -36,6 +37,7 @@ export default function UserProfileScreen() {
 
   const [identity, setIdentity] = useState<IdentityState>('loading');
   const [activities, setActivities] = useState<ReadingActivity[]>([]);
+  const [activitiesLoading, setActivitiesLoading] = useState(true);
   const [following, setFollowing] = useState(false);
   const [justFollowed, setJustFollowed] = useState(false);
 
@@ -53,10 +55,14 @@ export default function UserProfileScreen() {
   }, [user?.uid, uid, isOwnProfile]);
 
   useEffect(() => {
+    setActivitiesLoading(true);
     const unsubscribe = subscribeToReadingActivities(
       uid,
-      setActivities,
-      () => {},
+      (items) => {
+        setActivities(items);
+        setActivitiesLoading(false);
+      },
+      () => setActivitiesLoading(false),
     );
     return unsubscribe;
   }, [uid]);
@@ -195,7 +201,9 @@ export default function UserProfileScreen() {
 
         <Text style={styles.sectionHeader}>{t('shelf.finished')}</Text>
 
-        {activities.length === 0 ? (
+        {activitiesLoading ? (
+          <BookListSkeleton count={3} />
+        ) : activities.length === 0 ? (
           <Text style={styles.emptyText}>{t('userProfile.emptyBooks')}</Text>
         ) : (
           activities.map((item) => (


### PR DESCRIPTION
Replace bare spinners / blank states on DB-backed list screens with content-shaped skeleton placeholders to reduce perceived latency.

- add Skeleton primitive (pulse animation, reduce-motion aware, decorative/hidden from screen readers)
- add FeedSkeleton and BookListSkeleton matching existing card layouts
- distinguish "loading" vs "loaded-empty" via first-snapshot flags on Shelf and Profile; clear loading on error and when uid is absent
- start feed isLoading=true to avoid empty-state flash
- add common.loading i18n key (en/ja)