### PR TITLE
docs: ストア掲載文言(JP/EN)を追加 (#17)

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,0 +1,100 @@
+# よもーよ ストア掲載文言（App Store / Google Play）
+---
+
+## 【日本語】
+
+### 共通
+- アプリ名 / タイトル: **よもーよ**（8文字以内・30文字上限OK）
+- サブタイトル（App Store・30文字以内）: **誰かの読書が、次の読書に。**（13文字）
+- 短い説明（Google Play・80文字以内）:
+  > 誰かの「読み終わった」が、あなたの次の一冊に。静かで温かい読書記録アプリ。（37文字）
+
+### プロモーション用テキスト（App Store・170文字以内）
+> レビューもランキングもありません。フォローした人が本を読み終えたとき、そっと届く合図が、あなたの読書のきっかけになる。急かさない、比べない。読書そのものを大切にするアプリです。（88文字）
+
+### 説明文（App Store / Google Play 共通・4000文字以内）
+```
+よもーよは、「誰かの読書が、そっと次の読書につながる」ことだけを大切にした、静かで温かい読書アプリです。
+
+だれかがフォロー中の人が本を読み終えたとき、その小さな合図が「わたしも読んでみようかな」の入り口になる——。レビューを書く必要も、順位を競う必要もありません。
+
+■ よもーよでできること
+・読書の記録：読み始め・読み終わりを、ワンタップで軽やかに。
+・つながる：気になる人をフォローして、その人の読書をゆるやかに感じる。
+・フィード：フォローした人の読書がやさしく流れてくるタイムライン。
+・通知：フォローした人が「本を読み終えた」ときだけ、そっとお知らせ。
+
+■ よもーよが大切にしていること
+・ひとつの役割に集中：機能を盛り込みすぎません。
+・軽やかな操作：ワンタップで十分。分類や整理に頭を使わせません。
+・比べない・競わない：ランキングも連続記録もありません。
+・実世界の読書が主役：アプリはそれをそっと支えるだけ。
+・感情を邪魔しない広告：本を読み終えた大切な瞬間に広告は出しません。
+
+■ こんな方に
+・読書を静かに記録したい方
+・本好きの友だちと、ゆるくつながりたい方
+・SNSの喧騒に疲れた方
+・「次に何を読もう」を、誰かの読書からもらいたい方
+
+よもーよは無料でご利用いただけます（広告を含みます。広告は読書の余韻を邪魔しない場所にだけ、控えめに表示します）。
+
+さあ、あなたの読書を、そっと誰かへ。
+```
+
+### キーワード（App Store・100文字以内・カンマ区切り）
+> 読書,読書記録,読書管理,本,読書ログ,読書習慣,積読,本好き,読書仲間,フォロー,読書sns,ブックログ（例。実機で文字数調整）
+
+---
+
+## 【English】
+
+### Common
+- App Name / Title: **Yomoyo**
+- Subtitle (App Store, ≤30 chars): **Reading, gently shared.** (24 chars)
+- Short description (Google Play, ≤80 chars):
+  > When someone finishes a book, it quietly becomes your next read. (63 chars)
+
+### Promotional Text (App Store, ≤170 chars)
+> No reviews. No rankings. When someone you follow finishes a book, a quiet signal can become the start of your own reading. No pressure, no comparison — just reading. (162 chars)
+
+### Description (App Store / Google Play, ≤4000 chars)
+```
+Yomoyo is a calm, warm reading app built for one thing: the quiet spread of reading between people.
+
+When someone you follow finishes a book, that simple signal can become the start of your own reading — "maybe I'll read that too." No reviews to write. No rankings to climb. Just a gentle presence.
+
+■ What you can do
+- Log your reading: mark a book started or finished with a single tap.
+- Connect: follow people whose reading you'd love to feel.
+- Feed: a gentle timeline of what the people you follow are reading.
+- Notifications: you're notified only when someone you follow finishes a book.
+
+■ What Yomoyo values
+- A single, focused role — no feature overload.
+- Lightweight actions — one tap is enough, no sorting or organizing.
+- No comparison, no competition — no rankings, no streaks.
+- The real-world act of reading stays at the center.
+- Ads that respect your emotions — never during the moments that matter.
+
+■ Who it's for
+- Anyone who wants to quietly keep track of their reading.
+- Book lovers who want a calm, low-pressure way to stay connected.
+- People tired of noisy social feeds.
+- Anyone looking for their next read through the people they trust.
+
+Yomoyo is free to use and ad-supported. Ads appear only in low-sensitivity spots, never interrupting the emotional moments of reading.
+
+Let your reading gently inspire someone else.
+```
+
+### Keywords (App Store, ≤100 chars, comma-separated)
+> reading,book,reading log,book tracker,reading tracker,book log,reading list,book lovers,follow,reading habit
+
+---
+
+## 未確定・要対応
+- [ ] スクリーンショット（各デバイスサイズ）— 別途作成が必要（#17）
+- [ ] 実機ストア入力欄での文字数最終確認（特に App Store サブタイトル/キーワード）
+- [ ] EN 版の最終ネイティブチェック
+- [ ] プライバシーポリシー / 利用規約(ToS, PR #135) の公開URLをストアの該当欄に設定


### PR DESCRIPTION
## 概要

App Store / Google Play 向けの**ストア掲載文言（日本語・英語）**を `docs/store-listing.md` として追加します。

関連: #17（クローズせず。ストア説明文タスクのドラフトとして追加）

## 内容

- README のブランドボイス（静かで温かい／レビュー・ランキング・競争なし／実世界の読書が主役）に準拠
- **App Store**: アプリ名・サブタイトル・プロモーションテキスト・説明文・キーワード（JP/EN）
- **Google Play**: タイトル・短い説明・説明文（JP/EN）

## ⚠️ 公開前に確定が必要

- [ ] 実機ストア入力欄での文字数最終確認（特に App Store サブタイトル/キーワード）
- [ ] EN 版のネイティブチェック
- [ ] プライバシーポリシー / 利用規約(ToS: PR #135) の公開URLをストア該当欄に設定

## #17 の残タスク（本PR対象外）

- スクリーンショット（各デバイスサイズ）
- Expo EAS Build 設定

> 外部公開文言のため、最終確定・入稿は CEO 承認のうえ実施（AI-CEO 承認キュー AQ-106）。