### PR TITLE
chore: 本番安全ガード (seed-dev / debug functions) (#77)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,6 +17,24 @@ const REGION = 'asia-northeast1';
 const DEFAULT_TITLE = 'Yomoyo';
 const DEFAULT_BODY = '眠たいキツネが「ノルウェイの森」を読み終えました。';
 
+// ─── Debug callable guard ────────────────────────────────────────────────────
+// sendTestPush / dryRunResolveRecipients are development/debug utilities. They
+// must not be usable against the production project. They stay deployed (so dev
+// keeps them) but refuse to run in prod unless explicitly enabled.
+const PROD_PROJECT_ID = 'yomoyo-prod';
+
+function assertDebugCallablesAllowed(): void {
+  const projectId =
+    process.env.GCLOUD_PROJECT ?? process.env.GOOGLE_CLOUD_PROJECT;
+  const explicitlyEnabled = process.env.ENABLE_DEBUG_FUNCTIONS === 'true';
+  if (projectId === PROD_PROJECT_ID && !explicitlyEnabled) {
+    throw new HttpsError(
+      'permission-denied',
+      'Debug functions are disabled in production.',
+    );
+  }
+}
+
 interface SendTestPushInput {
   token?: string;
   title?: string;
@@ -26,6 +44,7 @@ interface SendTestPushInput {
 export const sendTestPush = onCall<SendTestPushInput>(
   { region: REGION, invoker: 'public' },
   async (req) => {
+    assertDebugCallablesAllowed();
     if (!req.auth) {
       throw new HttpsError('unauthenticated', 'Sign-in required.');
     }
@@ -117,6 +136,7 @@ interface DryRunResolveRecipientsResult {
 export const dryRunResolveRecipients = onCall<DryRunResolveRecipientsInput>(
   { region: REGION, invoker: 'public' },
   async (req): Promise<DryRunResolveRecipientsResult> => {
+    assertDebugCallablesAllowed();
     if (!req.auth) {
       throw new HttpsError('unauthenticated', 'Sign-in required.');
     }

--- a/scripts/seed-dev.js
+++ b/scripts/seed-dev.js
@@ -57,12 +57,39 @@ try {
 
 const SERVICE_ACCOUNT_PATH = path.resolve(__dirname, 'service-account.json');
 
+// ─── Production safety guard ─────────────────────────────────────────────────
+// This script writes fake "dev_" data straight into a live Firestore. If the
+// active credentials happen to point at the PRODUCTION project, seeding would
+// pollute real data. Refuse to run unless the resolved project is the known dev
+// project (or the operator explicitly overrides with --force).
+const DEV_PROJECT_ID = 'yomoyo-d9c4a';
+
+let serviceAccount = null;
 if (fs.existsSync(SERVICE_ACCOUNT_PATH)) {
-  const serviceAccount = require(SERVICE_ACCOUNT_PATH);
+  serviceAccount = require(SERVICE_ACCOUNT_PATH);
   admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
 } else {
   // Fall back to Application Default Credentials (firebase login / gcloud auth)
   admin.initializeApp();
+}
+
+const resolvedProjectId =
+  (serviceAccount && serviceAccount.project_id) ||
+  process.env.GOOGLE_CLOUD_PROJECT ||
+  process.env.GCLOUD_PROJECT ||
+  process.env.FIREBASE_PROJECT ||
+  admin.app().options.projectId ||
+  null;
+
+const forceSeed = process.argv.includes('--force');
+if (!forceSeed && resolvedProjectId !== DEV_PROJECT_ID) {
+  console.error('\n  ABORTED: seed-dev.js only runs against the dev project.');
+  console.error(`  expected project: ${DEV_PROJECT_ID}`);
+  console.error(`  resolved project: ${resolvedProjectId ?? '(unknown)'}`);
+  console.error('  Point your credentials at the dev project, e.g.:');
+  console.error(`    GOOGLE_CLOUD_PROJECT=${DEV_PROJECT_ID} node scripts/seed-dev.js`);
+  console.error('  or pass --force to override this guard (dangerous).\n');
+  process.exit(1);
 }
 
 const db = admin.firestore();


### PR DESCRIPTION
## 概要

#77 のdev/prod監査で挙がった **🟠 should-fix 2件**（本番安全ガード）に対応します。いずれも本番リリース前のリスク低減で、既存の開発フローは壊しません。

Refs #77

## 変更内容

### 1. `scripts/seed-dev.js` — 本番へのシード書き込みをガード
- このスクリプトは `dev_*` のダミーデータを**実Firestoreに直書き**するため、実行者の認証先が本番(`yomoyo-prod`)だと本番を汚染し得た。
- 解決されたプロジェクトIDが dev(`yomoyo-d9c4a`)でなければ **abort**（サービスアカウントJSONの `project_id` → `GOOGLE_CLOUD_PROJECT` 等 → `admin.app().options.projectId` の順で解決。不明な場合も安全側で停止）。
- 意図的に上書きしたい場合のみ `--force` で継続可能。
- 既存の seed/clean の挙動自体は不変。

### 2. `functions/src/index.ts` — デバッグCallableを本番で無効化
- `sendTestPush` / `dryRunResolveRecipients`（`invoker: public` のデバッグ用）が本番デプロイ対象だった。
- **削除はせず**、本番プロジェクト(`yomoyo-prod`)で実行された場合に `permission-denied` を返す `assertDebugCallablesAllowed()` を両ハンドラ先頭に追加。
- 必要時は `ENABLE_DEBUG_FUNCTIONS=true` で明示的に有効化可能（dev では従来どおり動作）。
- 判定は Cloud Functions ランタイムが自動設定する `GCLOUD_PROJECT`（fallback `GOOGLE_CLOUD_PROJECT`）を使用。

## テスト

- [x] `node --check scripts/seed-dev.js`（構文OK）
- [ ] ローカル/CI で `pnpm typecheck` / `pnpm test`（本環境にクローンが無いため未実施 — マージ前に確認をお願いします）

## 備考

- 代替案として「デバッグCallableを完全削除」も可能。今回は dev での有用性を残す安全側（本番のみ無効化）を採用。削除希望なら差し替えます。